### PR TITLE
Modifying backup code authenticator to store hash value of backup codes

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -1,19 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com) All Rights Reserved.
-~
-~ Licensed under the Apache License, Version 2.0 (the "License");
-~ you may not use this file except in compliance with the License.
-~ You may obtain a copy of the License at
-~
-~      http://www.apache.org/licenses/LICENSE-2.0
-~
-~ Unless required by applicable law or agreed to in writing, software
-~ distributed under the License is distributed on an "AS IS" BASIS,
-~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-~ See the License for the specific language governing permissions and
-~ limitations under the License.
--->
+  ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.backupcode</groupId>

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAPIHandler.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAPIHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -11,7 +11,7 @@
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -11,7 +11,7 @@
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
@@ -586,7 +586,7 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
             }
             return false;
         }
-        if (!backupCodeList.contains(BackupCodeAPIHandler.generateHashString(token))) {
+        if (!backupCodeList.contains(BackupCodeUtil.generateHashString(token))) {
             if (log.isDebugEnabled()) {
                 log.debug(String.format("Given code: %s does not match with any saved backup codes codes for user: %s",
                         token, userName));
@@ -612,7 +612,7 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
     private void removeUsedBackupCode(String userToken, String username, List<String> backupCodes)
             throws BackupCodeException, NoSuchAlgorithmException {
 
-        backupCodes.remove(BackupCodeAPIHandler.generateHashString(userToken));
+        backupCodes.remove(BackupCodeUtil.generateHashString(userToken));
         String unusedBackupCodes = String.join(",", backupCodes);
         String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
         try {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
@@ -277,7 +277,7 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
             } else {
                 context.setSubject(AuthenticatedUser.createLocalAuthenticatedUserFromSubjectIdentifier(username));
             }
-        } catch (BackupCodeException | NoSuchAlgorithmException e) {
+        } catch (BackupCodeException e) {
             throw new AuthenticationFailedException("Backup code Authentication process failed for user " + username,
                     e);
         }
@@ -517,7 +517,7 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
      * @throws BackupCodeException If an error occurred while validating token.
      */
     private boolean isValidTokenFederatedUser(String code, AuthenticationContext context, String userName)
-            throws BackupCodeException, NoSuchAlgorithmException {
+            throws BackupCodeException {
 
         String backupCodes = null;
         if (context.getProperty(BACKUP_CODES_CLAIM) != null) {
@@ -558,14 +558,14 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
                         String.format(ERROR_CODE_ERROR_FIND_USER_REALM.getMessage(),
                                 CarbonContext.getThreadLocalCarbonContext().getTenantDomain()));
             }
-        } catch (UserStoreException | NoSuchAlgorithmException e) {
+        } catch (UserStoreException e) {
             throw new BackupCodeException(ERROR_CODE_ERROR_ACCESS_USER_REALM.getCode(),
                     String.format(ERROR_CODE_ERROR_ACCESS_USER_REALM.getMessage(), tenantAwareUsername, e));
         }
     }
 
     private boolean isValidBackupCode(String token, AuthenticationContext context, String userName,
-                                      String hashedBackupCodes) throws BackupCodeException, NoSuchAlgorithmException {
+                                      String hashedBackupCodes) throws BackupCodeException {
 
         if (StringUtils.isBlank(hashedBackupCodes)) {
             if (log.isDebugEnabled()) {
@@ -610,7 +610,7 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
      * @throws BackupCodeException If an error occurred while removing the used backup code.
      */
     private void removeUsedBackupCode(String userToken, String username, List<String> backupCodes)
-            throws BackupCodeException, NoSuchAlgorithmException {
+            throws BackupCodeException {
 
         backupCodes.remove(BackupCodeUtil.generateHashString(userToken));
         String unusedBackupCodes = String.join(",", backupCodes);

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/connector/BackupCodeAuthenticatorConfigImpl.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/connector/BackupCodeAuthenticatorConfigImpl.java
@@ -28,12 +28,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.BACKUP_CODES_SIZE;
+import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.REQUIRED_NO_OF_BACKUP_CODES;
 import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.BACKUP_CODE_AUTHENTICATOR_FRIENDLY_NAME;
 import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.BACKUP_CODE_AUTHENTICATOR_NAME;
-import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.BACKUP_CODE_LENGTH;
-import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.DEFAULT_BACKUP_CODES_SIZE;
-import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.DEFAULT_BACKUP_CODE_LENGTH;
+import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.LENGTH_OF_BACKUP_CODE;
+import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.DEFAULT_NO_OF_BACKUP_CODES;
+import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.DEFAULT_LENGTH_OF_BACKUP_CODE;
 
 /**
  * This class contains the authenticator config implementation.
@@ -74,8 +74,8 @@ public class BackupCodeAuthenticatorConfigImpl implements IdentityConnectorConfi
     public Map<String, String> getPropertyNameMapping() {
 
         Map<String, String> nameMapping = new HashMap<>();
-        nameMapping.put(BACKUP_CODE_LENGTH, "Backup code length");
-        nameMapping.put(BACKUP_CODES_SIZE, "Backup code size");
+        nameMapping.put(LENGTH_OF_BACKUP_CODE, "Backup code length");
+        nameMapping.put(REQUIRED_NO_OF_BACKUP_CODES, "Backup code size");
         return nameMapping;
     }
 
@@ -83,8 +83,8 @@ public class BackupCodeAuthenticatorConfigImpl implements IdentityConnectorConfi
     public Map<String, String> getPropertyDescriptionMapping() {
 
         Map<String, String> descriptionMapping = new HashMap<>();
-        descriptionMapping.put(BACKUP_CODE_LENGTH, "Length of a backup code");
-        descriptionMapping.put(BACKUP_CODES_SIZE, "Maximum number of backup codes");
+        descriptionMapping.put(LENGTH_OF_BACKUP_CODE, "Length of a backup code");
+        descriptionMapping.put(REQUIRED_NO_OF_BACKUP_CODES, "Maximum number of backup codes");
         return descriptionMapping;
     }
 
@@ -92,19 +92,19 @@ public class BackupCodeAuthenticatorConfigImpl implements IdentityConnectorConfi
     public String[] getPropertyNames() {
 
         List<String> properties = new ArrayList<>();
-        properties.add(BACKUP_CODE_LENGTH);
-        properties.add(BACKUP_CODES_SIZE);
+        properties.add(LENGTH_OF_BACKUP_CODE);
+        properties.add(REQUIRED_NO_OF_BACKUP_CODES);
         return properties.toArray(new String[0]);
     }
 
     @Override
     public Properties getDefaultPropertyValues(String s) throws IdentityGovernanceException {
 
-        String backupCodeLength = String.valueOf(DEFAULT_BACKUP_CODE_LENGTH);
-        String backupCodesSize = String.valueOf(DEFAULT_BACKUP_CODES_SIZE);
+        String backupCodeLength = String.valueOf(DEFAULT_LENGTH_OF_BACKUP_CODE);
+        String backupCodesSize = String.valueOf(DEFAULT_NO_OF_BACKUP_CODES);
 
-        String backupCodeLengthProperty = IdentityUtil.getProperty(BACKUP_CODE_LENGTH);
-        String backupCodesSizeProperty = IdentityUtil.getProperty(BACKUP_CODES_SIZE);
+        String backupCodeLengthProperty = IdentityUtil.getProperty(LENGTH_OF_BACKUP_CODE);
+        String backupCodesSizeProperty = IdentityUtil.getProperty(REQUIRED_NO_OF_BACKUP_CODES);
 
         if (StringUtils.isNotBlank(backupCodeLengthProperty)) {
             backupCodeLength = backupCodeLengthProperty;
@@ -114,8 +114,8 @@ public class BackupCodeAuthenticatorConfigImpl implements IdentityConnectorConfi
         }
 
         Map<String, String> defaultProperties = new HashMap<>();
-        defaultProperties.put(BACKUP_CODE_LENGTH, backupCodeLength);
-        defaultProperties.put(BACKUP_CODES_SIZE, backupCodesSize);
+        defaultProperties.put(LENGTH_OF_BACKUP_CODE, backupCodeLength);
+        defaultProperties.put(REQUIRED_NO_OF_BACKUP_CODES, backupCodesSize);
 
         Properties properties = new Properties();
         properties.putAll(defaultProperties);

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/connector/BackupCodeAuthenticatorConfigImpl.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/connector/BackupCodeAuthenticatorConfigImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -11,7 +11,7 @@
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/constants/BackupCodeAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/constants/BackupCodeAuthenticatorConstants.java
@@ -25,11 +25,11 @@ public class BackupCodeAuthenticatorConstants {
     public static final String BACKUP_CODE_AUTHENTICATOR_NAME = "backup-code-authenticator";
     public static final String BACKUP_CODE_AUTHENTICATOR_FRIENDLY_NAME = "Backup Code Authenticator";
     public static final String BACKUP_CODE_NUMERIC_CHAR_SET = "9245378016";
-    public static final int DEFAULT_BACKUP_CODE_LENGTH = 6;
-    public static final int DEFAULT_BACKUP_CODES_SIZE = 10;
+    public static final int DEFAULT_LENGTH_OF_BACKUP_CODE = 6;
+    public static final int DEFAULT_NO_OF_BACKUP_CODES = 10;
 
-    public static final String BACKUP_CODE_LENGTH = "BackupCode.BackupCodeLength";
-    public static final String BACKUP_CODES_SIZE = "BackupCode.BackupCodeSize";
+    public static final String LENGTH_OF_BACKUP_CODE = "BackupCode.BackupCodeLength";
+    public static final String REQUIRED_NO_OF_BACKUP_CODES = "BackupCode.BackupCodeSize";
     public static final String BACKUP_CODE = "BackupCode";
     public static final String SEND_TOKEN = "sendToken";
     public static final String ENABLE_BACKUP_CODE = "ENABLE_BACKUP_CODE";
@@ -51,20 +51,21 @@ public class BackupCodeAuthenticatorConstants {
 
     public enum ErrorMessages {
 
-        ERROR_CODE_INVALID_FEDERATED_AUTHENTICATOR("65001",
-                "No IDP found with the name IDP: " + "%s in tenant: %s"), ERROR_CODE_NO_FEDERATED_USER("65002",
-                "No federated user found"), ERROR_CODE_INVALID_FEDERATED_USER_AUTHENTICATION("65003",
-                "Can not handle federated user " +
-                        "authentication with Backup Code as JIT Provision is not enabled for the IDP: in the tenant: %s"), ERROR_CODE_NO_AUTHENTICATED_USER(
-                "65004", "Can not find the authenticated user"), ERROR_CODE_ERROR_UPDATING_BACKUP_CODES("65006",
-                "Error occurred while updating unused backup codes for user: %s"), ERROR_CODE_ERROR_TRIGGERING_EVENT(
-                "65007",
-                "Error occurred while triggering event: %s for the user: %s"), ERROR_CODE_ERROR_FIND_USER_REALM("65008",
-                "Cannot find the user realm for the given tenant domain : %s"), ERROR_CODE_ERROR_ACCESS_USER_REALM(
-                "65009",
-                "Error occurred failed while trying to access userRealm of the user : %s"), ERROR_CODE_ERROR_HASH_BACKUP_CODE(
-                "65010", "Error occurred while hashing backup codes"), ERROR_CODE_ERROR_GETTING_CONFIG("65012",
-                "Error occurred while getting backup code configurations");
+        ERROR_NO_USERNAME("60001", "Username cannot be empty"),
+        INVALID_FEDERATED_AUTHENTICATOR("65001", "No IDP found with the name IDP: " + "%s in tenant: %s"),
+        ERROR_NO_FEDERATED_USER("65002", "No federated user found"),
+        INVALID_FEDERATED_USER_AUTHENTICATION("65003", "Can not handle federated user " +
+                        "authentication with Backup Code as JIT Provision is not enabled for the IDP: in the tenant: %s"),
+        ERROR_NO_AUTHENTICATED_USER("65004", "Can not find the authenticated user"),
+        ERROR_UPDATING_BACKUP_CODES("65006",
+                "Error occurred while updating unused backup codes for user: %s"),
+        ERROR_TRIGGERING_EVENT("65007", "Error occurred while triggering event: %s for the user: %s"),
+        ERROR_FIND_USER_REALM("65008", "Cannot find the user realm for the given tenant domain : %s"),
+        ERROR_ACCESS_USER_REALM("65009",
+                "Error occurred failed while trying to access userRealm of the user : %s"),
+        ERROR_HASH_BACKUP_CODE("65010", "Error occurred while hashing backup codes"),
+        ERROR_GETTING_CONFIG("65011", "Error occurred while getting backup code configurations");
+
         private final String code;
         private final String message;
 

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/constants/BackupCodeAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/constants/BackupCodeAuthenticatorConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -11,7 +11,7 @@
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/constants/BackupCodeAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/constants/BackupCodeAuthenticatorConstants.java
@@ -62,9 +62,8 @@ public class BackupCodeAuthenticatorConstants {
                 "Error occurred while triggering event: %s for the user: %s"), ERROR_CODE_ERROR_FIND_USER_REALM("65008",
                 "Cannot find the user realm for the given tenant domain : %s"), ERROR_CODE_ERROR_ACCESS_USER_REALM(
                 "65009",
-                "Error occurred failed while trying to access userRealm of the user : %s"), ERROR_CODE_ERROR_DECRYPT_BACKUP_CODE(
-                "65010", "Error occurred while decrypting backup codes"), ERROR_CODE_ERROR_ENCRYPT_BACKUP_CODE("65011",
-                "Error occurred while encrypting backup codes"), ERROR_CODE_ERROR_GETTING_CONFIG("65012",
+                "Error occurred failed while trying to access userRealm of the user : %s"), ERROR_CODE_ERROR_HASH_BACKUP_CODE(
+                "65010", "Error occurred while hashing backup codes"), ERROR_CODE_ERROR_GETTING_CONFIG("65012",
                 "Error occurred while getting backup code configurations");
         private final String code;
         private final String message;

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/constants/BackupCodeAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/constants/BackupCodeAuthenticatorConstants.java
@@ -64,7 +64,10 @@ public class BackupCodeAuthenticatorConstants {
         ERROR_ACCESS_USER_REALM("65009",
                 "Error occurred failed while trying to access userRealm of the user : %s"),
         ERROR_HASH_BACKUP_CODE("65010", "Error occurred while hashing backup codes"),
-        ERROR_GETTING_CONFIG("65011", "Error occurred while getting backup code configurations");
+        ERROR_GETTING_CONFIG("65011", "Error occurred while getting backup code configurations"),
+        ERROR_GETTING_THE_USER_REALM("65012", "Error occurred while getting the user realm"),
+        ERROR_GETTING_THE_USER_STORE_MANAGER("65013", "Error occurred while getting the user store manager"),
+        ERROR_SETTING_USER_CLAIM_VALUES("65014", "Error occurred while setting user claim values");
 
         private final String code;
         private final String message;

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/exception/BackupCodeClientException.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/exception/BackupCodeClientException.java
@@ -1,0 +1,17 @@
+package org.wso2.carbon.identity.application.authenticator.backupcode.exception;
+
+/**
+ * Backup code client related exceptions.
+ */
+public class BackupCodeClientException extends BackupCodeException{
+
+    /**
+     * Backup code client related exceptions.
+     *
+     * @param errorCode Error code.
+     * @param msg       Error message.
+     */
+    public BackupCodeClientException(String errorCode, String msg) {
+        super(errorCode, msg);
+    }
+}

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/exception/BackupCodeClientException.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/exception/BackupCodeClientException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -11,7 +11,7 @@
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/exception/BackupCodeClientException.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/exception/BackupCodeClientException.java
@@ -1,9 +1,26 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.wso2.carbon.identity.application.authenticator.backupcode.exception;
 
 /**
  * Backup code client related exceptions.
  */
-public class BackupCodeClientException extends BackupCodeException{
+public class BackupCodeClientException extends BackupCodeException {
 
     /**
      * Backup code client related exceptions.
@@ -12,6 +29,7 @@ public class BackupCodeClientException extends BackupCodeException{
      * @param msg       Error message.
      */
     public BackupCodeClientException(String errorCode, String msg) {
+
         super(errorCode, msg);
     }
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/exception/BackupCodeException.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/exception/BackupCodeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -11,7 +11,7 @@
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/internal/BackupCodeAuthenticatorServiceComponent.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/internal/BackupCodeAuthenticatorServiceComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -11,7 +11,7 @@
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/internal/BackupCodeDataHolder.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/internal/BackupCodeDataHolder.java
@@ -1,20 +1,19 @@
 /*
- *  Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *  in compliance with the License.
- *  You may obtain a copy of the License at
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied.  See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
- *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.wso2.carbon.identity.application.authenticator.backupcode.internal;
 

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/util/BackupCodeUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/util/BackupCodeUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -11,7 +11,7 @@
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/util/BackupCodeUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/util/BackupCodeUtil.java
@@ -50,6 +50,8 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
@@ -79,6 +81,7 @@ import static org.wso2.carbon.identity.application.authenticator.backupcode.cons
 public class BackupCodeUtil {
 
     private static final Log log = LogFactory.getLog(BackupCodeUtil.class);
+    private static final String TOKEN_HASH_METHOD = "SHA-256";
 
     /**
      * Returns AuthenticatedUser object from context.
@@ -365,7 +368,7 @@ public class BackupCodeUtil {
      * @return Generated backup codes.
      * @throws BackupCodeException If an error occurred while generating backup codes.
      */
-    public static String generateBackupCodes(String tenantDomain) throws BackupCodeException {
+    public static List<String> generateBackupCodes(String tenantDomain) throws BackupCodeException {
 
         int backupCodeLength = getBackupCodeLength(tenantDomain);
         int backupCodesSize = getBackupCodesSize(tenantDomain);
@@ -373,7 +376,7 @@ public class BackupCodeUtil {
         for (int i = 0; i < backupCodesSize; i++) {
             backupCodes.add(generateBackupCode(backupCodeLength));
         }
-        return String.join(",", backupCodes);
+        return backupCodes;
     }
 
     private static String generateBackupCode(int length) {
@@ -442,6 +445,24 @@ public class BackupCodeUtil {
             throw new BackupCodeException(ERROR_CODE_ERROR_GETTING_CONFIG.getCode(),
                     ERROR_CODE_ERROR_GETTING_CONFIG.getMessage(), e);
         }
+    }
+
+    /**
+     * Generate the hash value of the given string.
+     *
+     * @param backupCode String value that needs to hash.
+     * @return Hash value of the backupCode.
+     * @throws NoSuchAlgorithmException If the algorithms is invalid.
+     */
+    public static String generateHashString(String backupCode) throws NoSuchAlgorithmException {
+
+        MessageDigest messageDigest = MessageDigest.getInstance(TOKEN_HASH_METHOD);
+        byte[] in = messageDigest.digest(backupCode.getBytes(StandardCharsets.UTF_8));
+        final StringBuilder builder = new StringBuilder();
+        for (byte b : in) {
+            builder.append(String.format("%02x", b));
+        }
+        return builder.toString();
     }
 }
 

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/util/BackupCodeUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/util/BackupCodeUtil.java
@@ -71,6 +71,7 @@ import static org.wso2.carbon.identity.application.authenticator.backupcode.cons
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.ERROR_PAGE;
 import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.ErrorMessages.ERROR_CODE_ERROR_GETTING_CONFIG;
+import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.ErrorMessages.ERROR_CODE_ERROR_HASH_BACKUP_CODE;
 import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.LOCAL_AUTHENTICATOR;
 import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.LOGIN_PAGE;
 import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.SUPER_TENANT_DOMAIN;
@@ -452,17 +453,23 @@ public class BackupCodeUtil {
      *
      * @param backupCode String value that needs to hash.
      * @return Hash value of the backupCode.
-     * @throws NoSuchAlgorithmException If the algorithms is invalid.
+     * @throws BackupCodeException If the algorithms is invalid.
      */
-    public static String generateHashString(String backupCode) throws NoSuchAlgorithmException {
+    public static String generateHashString(String backupCode) throws BackupCodeException {
 
-        MessageDigest messageDigest = MessageDigest.getInstance(TOKEN_HASH_METHOD);
-        byte[] in = messageDigest.digest(backupCode.getBytes(StandardCharsets.UTF_8));
-        final StringBuilder builder = new StringBuilder();
-        for (byte b : in) {
-            builder.append(String.format("%02x", b));
+        try {
+            MessageDigest messageDigest = MessageDigest.getInstance(TOKEN_HASH_METHOD);
+            byte[] in = messageDigest.digest(backupCode.getBytes(StandardCharsets.UTF_8));
+            final StringBuilder builder = new StringBuilder();
+            for (byte b : in) {
+                builder.append(String.format("%02x", b));
+            }
+            return builder.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new BackupCodeException(ERROR_CODE_ERROR_HASH_BACKUP_CODE.getCode(),
+                    ERROR_CODE_ERROR_HASH_BACKUP_CODE.getMessage(), e);
         }
-        return builder.toString();
+
     }
 }
 

--- a/component/authenticator/src/test/resources/testng.xml
+++ b/component/authenticator/src/test/resources/testng.xml
@@ -1,6 +1,5 @@
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 <!--
-  ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com) All Rights Reserved.
+  ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
   ~
   ~ WSO2 Inc. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -12,10 +11,12 @@
   ~ Unless required by applicable law or agreed to in writing,
   ~ software distributed under the License is distributed on an
   ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied. See the License for the
+  ~ KIND, either express or implied.  See the License for the
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
 <suite name="Suite1" verbose="1" >
 

--- a/feature/feature.properties
+++ b/feature/feature.properties
@@ -1,18 +1,20 @@
-################################################################################
-# Copyright 2022 WSO2, Inc. (http://wso2.com)
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
+# Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
 # You may obtain a copy of the License at
 #
 # http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-################################################################################
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 
 providerName=WSO2 Inc.
 

--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -1,19 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com) All Rights Reserved.
- ~
- ~ Licensed under the Apache License, Version 2.0 (the "License");
- ~ you may not use this file except in compliance with the License.
- ~ You may obtain a copy of the License at
- ~
- ~      http://www.apache.org/licenses/LICENSE-2.0
- ~
- ~ Unless required by applicable law or agreed to in writing, software
- ~ distributed under the License is distributed on an "AS IS" BASIS,
- ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- ~ See the License for the specific language governing permissions and
- ~ limitations under the License.
--->
+  ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.backupcode</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com) All Rights Reserved.
+  ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
   ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~ http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
## Purpose

 Currently, encrypted values of backup codes are stored in databases. As a security precaution, we need to store the hash value of the backup codes in the database. With this PR,

- hashed values of backup codes will be stored instead of the encrypted values.
- authentication process is modified to authenticate hashed backup codes.

## Related Git Issue

- [https://github.com/wso2-enterprise/asgardeo-product/issues/11121](https://github.com/wso2-enterprise/asgardeo-product/issues/11121)
