### PR TITLE
Add support to send error code when account is locked

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
@@ -491,29 +491,28 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
         String errorParam = StringUtils.EMPTY;
         IdentityErrorMsgContext errorContext = IdentityUtil.getIdentityErrorMsg();
         IdentityUtil.clearIdentityErrorMsg();
-        if (errorContext != null && errorContext.getErrorCode() != null) {
-
-            log.debug("Identity error message context is not null");
-
+        if (errorContext != null) {
+            log.debug("Identity error message context is not null.");
             String errorCode = errorContext.getErrorCode();
             String reason = null;
-
-            String[] errorCodeWithReason = errorCode.split(":", 2);
-            errorCode = errorCodeWithReason[0];
-            if (errorCodeWithReason.length > 1) {
-                reason = errorCodeWithReason[1];
-            }
-            if (errorCode.equals(UserCoreConstants.ErrorCode.USER_IS_LOCKED)) {
-                Map<String, String> paramMap = new HashMap<>();
-                paramMap.put(ERROR_CODE, errorCode);
-                if (StringUtils.isNotBlank(reason)) {
-                    paramMap.put(LOCKED_REASON, reason);
-                } else if ( errorContext.getFailedLoginAttempts() !=0 &&
-                        errorContext.getFailedLoginAttempts() == errorContext.getMaximumLoginAttempts()) {
-                    // The account just got locked because of max attempts reached.
-                    paramMap.put(LOCKED_REASON, BackupCodeAuthenticatorConstants.MAX_ATTEMPTS_EXCEEDED);
+            if (errorCode != null) {
+                String[] errorCodeWithReason = errorCode.split(":", 2);
+                errorCode = errorCodeWithReason[0];
+                if (errorCodeWithReason.length > 1) {
+                    reason = errorCodeWithReason[1];
                 }
-                errorParam = buildErrorParamString(paramMap);
+                if (errorCode.equals(UserCoreConstants.ErrorCode.USER_IS_LOCKED)) {
+                    Map<String, String> paramMap = new HashMap<>();
+                    paramMap.put(ERROR_CODE, errorCode);
+                    if (StringUtils.isNotBlank(reason)) {
+                        paramMap.put(LOCKED_REASON, reason);
+                    } else if (errorContext.getFailedLoginAttempts() != 0 &&
+                            errorContext.getFailedLoginAttempts() == errorContext.getMaximumLoginAttempts()) {
+                        // The account just got locked because of max attempts reached.
+                        paramMap.put(LOCKED_REASON, BackupCodeAuthenticatorConstants.MAX_ATTEMPTS_EXCEEDED);
+                    }
+                    errorParam = buildErrorParamString(paramMap);
+                }
             }
         }
         return errorParam;

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.org).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
@@ -121,7 +121,7 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
     public boolean canHandle(HttpServletRequest httpServletRequest) {
 
         String token = httpServletRequest.getParameter(BACKUP_CODE);
-        return (token != null);
+        return (StringUtils.isNotBlank(token));
     }
 
     /**
@@ -493,7 +493,7 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
             log.debug("Identity error message context is not null.");
             String errorCode = errorContext.getErrorCode();
             String reason = null;
-            if (errorCode != null) {
+            if (StringUtils.isNotBlank(errorCode)) {
                 String[] errorCodeWithReason = errorCode.split(":", 2);
                 errorCode = errorCodeWithReason[0];
                 if (errorCodeWithReason.length > 1) {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
@@ -159,15 +159,6 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
 
         String username = null;
         String tenantDomain = context.getTenantDomain();
-
-        Map<String, String> parameterMap = getAuthenticatorConfig().getParameterMap();
-        boolean showAuthFailureReason = Boolean.parseBoolean(parameterMap.get(
-                FrameworkConstants.SHOW_AUTHFAILURE_RESON_CONFIG));
-        boolean showAuthFailureReasonOnLoginPage = false;
-        if (showAuthFailureReason) {
-            showAuthFailureReasonOnLoginPage = Boolean.parseBoolean(
-                    parameterMap.get(FrameworkConstants.SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE_CONF));
-        }
         context.setProperty(AUTHENTICATION, BACKUP_CODE_AUTHENTICATOR_NAME);
         if (!tenantDomain.equals(SUPER_TENANT_DOMAIN)) {
             IdentityHelperUtil.loadApplicationAuthenticationXMLFromRegistry(context, getName(), tenantDomain);
@@ -201,6 +192,14 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
             String retryParam = StringUtils.EMPTY;
             if (context.isRetrying()) {
                 retryParam = "&authFailure=true&authFailureMsg=login.fail.message";
+            }
+            Map<String, String> parameterMap = getAuthenticatorConfig().getParameterMap();
+            boolean showAuthFailureReason = Boolean.parseBoolean(parameterMap.get(
+                    FrameworkConstants.SHOW_AUTHFAILURE_RESON_CONFIG));
+            boolean showAuthFailureReasonOnLoginPage = false;
+            if (showAuthFailureReason) {
+                showAuthFailureReasonOnLoginPage = Boolean.parseBoolean(
+                        parameterMap.get(FrameworkConstants.SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE_CONF));
             }
             String errorParam = StringUtils.EMPTY;
             if (showAuthFailureReason) {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.carbon.identity.application.authenticator.backupcode;
 
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants;
 import org.wso2.carbon.identity.application.authenticator.backupcode.exception.BackupCodeException;
 import org.wso2.carbon.identity.application.authenticator.backupcode.internal.BackupCodeDataHolder;
@@ -63,10 +64,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.SESSION_DATA_KEY;
-import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.CONF_SHOW_AUTH_FAILURE_REASON;
-import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.CONF_SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE;
-import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.ERROR_CODE;
-import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.LOCKED_REASON;
 import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.AUTHENTICATED_USER;
 import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.AUTHENTICATION;
 import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.BACKUP_CODE_AUTHENTICATOR_FRIENDLY_NAME;
@@ -164,11 +161,11 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
         String tenantDomain = context.getTenantDomain();
 
         Map<String, String> parameterMap = getAuthenticatorConfig().getParameterMap();
-        boolean showAuthFailureReason = Boolean.parseBoolean(parameterMap.get(CONF_SHOW_AUTH_FAILURE_REASON));
+        boolean showAuthFailureReason = Boolean.parseBoolean(parameterMap.get(FrameworkConstants.SHOW_AUTHFAILURE_RESON_CONFIG));
         boolean showAuthFailureReasonOnLoginPage = false;
         if (showAuthFailureReason) {
             showAuthFailureReasonOnLoginPage = Boolean.parseBoolean(
-                    parameterMap.get(CONF_SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE));
+                    parameterMap.get(FrameworkConstants.SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE_CONF));
         }
         context.setProperty(AUTHENTICATION, BACKUP_CODE_AUTHENTICATOR_NAME);
         if (!tenantDomain.equals(SUPER_TENANT_DOMAIN)) {
@@ -503,13 +500,13 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
                 }
                 if (errorCode.equals(UserCoreConstants.ErrorCode.USER_IS_LOCKED)) {
                     Map<String, String> paramMap = new HashMap<>();
-                    paramMap.put(ERROR_CODE, errorCode);
+                    paramMap.put(FrameworkConstants.ERROR_CODE, errorCode);
                     if (StringUtils.isNotBlank(reason)) {
-                        paramMap.put(LOCKED_REASON, reason);
-                    } else if (errorContext.getFailedLoginAttempts() != 0 &&
-                            errorContext.getFailedLoginAttempts() == errorContext.getMaximumLoginAttempts()) {
+                        paramMap.put(FrameworkConstants.LOCK_REASON, reason);
+                    } else if (errorContext.getFailedLoginAttempts() == errorContext.getMaximumLoginAttempts()) {
                         // The account just got locked because of max attempts reached.
-                        paramMap.put(LOCKED_REASON, BackupCodeAuthenticatorConstants.MAX_ATTEMPTS_EXCEEDED);
+                        paramMap.put(FrameworkConstants.LOCK_REASON,
+                                BackupCodeAuthenticatorConstants.MAX_ATTEMPTS_EXCEEDED);
                     }
                     errorParam = buildErrorParamString(paramMap);
                 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
@@ -197,11 +197,11 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
             username = UserCoreUtil.addTenantDomainToEntry(authenticatingUser.getUserName(), tenantDomain);
             context.setProperty(AUTHENTICATED_USER, authenticatingUser);
 
-            String retryParam = "";
+            String retryParam = StringUtils.EMPTY;
             if (context.isRetrying()) {
                 retryParam = "&authFailure=true&authFailureMsg=login.fail.message";
             }
-            String errorParam="";
+            String errorParam=StringUtils.EMPTY;
             if (Boolean.parseBoolean(showAuthFailureReasonOnLoginPage)) {
                 errorParam = getErrorParamsStringFromErrorContext();
             }
@@ -482,7 +482,7 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
 
     private String getErrorParamsStringFromErrorContext() {
 
-        String errorParam = "";
+        String errorParam = StringUtils.EMPTY;
         IdentityErrorMsgContext errorContext = IdentityUtil.getIdentityErrorMsg();
         IdentityUtil.clearIdentityErrorMsg();
         if (errorContext != null && errorContext.getErrorCode() != null) {
@@ -496,7 +496,6 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
             errorCode = errorCodeWithReason[0];
             if (errorCodeWithReason.length > 1) {
                 reason = errorCodeWithReason[1];
-
             }
             if (errorCode.equals(UserCoreConstants.ErrorCode.USER_IS_LOCKED)) {
                 Map<String, String> paramMap = new HashMap<>();
@@ -556,7 +555,8 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
     }
 
     private void setErrorContextWhenAccountLocked(String username) throws AuthenticationFailedException {
-        String accountLockedReason = "";
+
+        String accountLockedReason = StringUtils.EMPTY;
         String tenantAwareUsername;
         try {
             tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
@@ -161,7 +161,8 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
         String tenantDomain = context.getTenantDomain();
 
         Map<String, String> parameterMap = getAuthenticatorConfig().getParameterMap();
-        boolean showAuthFailureReason = Boolean.parseBoolean(parameterMap.get(FrameworkConstants.SHOW_AUTHFAILURE_RESON_CONFIG));
+        boolean showAuthFailureReason = Boolean.parseBoolean(parameterMap.get(
+                FrameworkConstants.SHOW_AUTHFAILURE_RESON_CONFIG));
         boolean showAuthFailureReasonOnLoginPage = false;
         if (showAuthFailureReason) {
             showAuthFailureReasonOnLoginPage = Boolean.parseBoolean(

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/constants/BackupCodeAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/constants/BackupCodeAuthenticatorConstants.java
@@ -48,6 +48,11 @@ public class BackupCodeAuthenticatorConstants {
     public static final String IS_INITIAL_FEDERATED_USER_ATTEMPT = "isInitialFederationAttempt";
     public static final String CODE_MISMATCH = "codeMismatch";
     public static final String GET_PROPERTY_FROM_IDENTITY_CONFIG = "getPropertiesFromLocal";
+    public static final String MAX_ATTEMPTS_EXCEEDED = "MAX_ATTEMPTS_EXCEEDED";
+    public static final String ADMIN_INITIATED = "ADMIN_INITIATED";
+    public static final String CONF_SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE = "showAuthFailureReasonOnLoginPage";
+    public static final String ERROR_CODE = "errorCode";
+    public static final String LOCKED_REASON = "lockedReason";
 
     public enum ErrorMessages {
 
@@ -104,5 +109,6 @@ public class BackupCodeAuthenticatorConstants {
         public static final String BACKUP_CODES_ENABLED_CLAIM = "http://wso2.org/claims/identity/backupCodeEnabled";
         public static final String BACKUP_CODE_FAILED_ATTEMPTS_CLAIM =
                 "http://wso2.org/claims/identity/failedBackupCodeAttempts";
+        public static final String ACCOUNT_LOCKED_REASON_CLAIM = "http://wso2.org/claims/identity/lockedReason";
     }
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/constants/BackupCodeAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/constants/BackupCodeAuthenticatorConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.prg).
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.org).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/constants/BackupCodeAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/constants/BackupCodeAuthenticatorConstants.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.prg).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/constants/BackupCodeAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/constants/BackupCodeAuthenticatorConstants.java
@@ -50,10 +50,6 @@ public class BackupCodeAuthenticatorConstants {
     public static final String GET_PROPERTY_FROM_IDENTITY_CONFIG = "getPropertiesFromLocal";
     public static final String MAX_ATTEMPTS_EXCEEDED = "MAX_ATTEMPTS_EXCEEDED";
     public static final String ADMIN_INITIATED = "ADMIN_INITIATED";
-    public static final String CONF_SHOW_AUTH_FAILURE_REASON = "showAuthFailureReason";
-    public static final String CONF_SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE = "showAuthFailureReasonOnLoginPage";
-    public static final String ERROR_CODE = "errorCode";
-    public static final String LOCKED_REASON = "lockedReason";
 
     public enum ErrorMessages {
 

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/constants/BackupCodeAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/constants/BackupCodeAuthenticatorConstants.java
@@ -50,6 +50,7 @@ public class BackupCodeAuthenticatorConstants {
     public static final String GET_PROPERTY_FROM_IDENTITY_CONFIG = "getPropertiesFromLocal";
     public static final String MAX_ATTEMPTS_EXCEEDED = "MAX_ATTEMPTS_EXCEEDED";
     public static final String ADMIN_INITIATED = "ADMIN_INITIATED";
+    public static final String CONF_SHOW_AUTH_FAILURE_REASON = "showAuthFailureReason";
     public static final String CONF_SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE = "showAuthFailureReasonOnLoginPage";
     public static final String ERROR_CODE = "errorCode";
     public static final String LOCKED_REASON = "lockedReason";

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.org).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticatorTest.java
@@ -224,9 +224,9 @@ public class BackupCodeAuthenticatorTest extends PowerMockTestCase {
 
         BackupCodeAuthenticator backupCodeAuthenticator = new BackupCodeAuthenticator();
         Map<String, String> parameterMap = new HashMap<>();
-        parameterMap.put(FrameworkConstants.SHOW_AUTHFAILURE_RESON_CONFIG, "false");
+        parameterMap.put(FrameworkConstants.SHOW_AUTHFAILURE_RESON_CONFIG, String.valueOf(false));
         AuthenticatorConfig authenticatorConfig = new AuthenticatorConfig(
-                "backup-code-authenticator", true, parameterMap);
+                BackupCodeAuthenticatorConstants.BACKUP_CODE_AUTHENTICATOR_NAME, true, parameterMap);
         try {
             mockStatic(BackupCodeUtil.class);
             mockStatic(FederatedAuthenticatorUtil.class);
@@ -310,11 +310,11 @@ public class BackupCodeAuthenticatorTest extends PowerMockTestCase {
     }
 
     @Test(dataProvider = "initiateAuthenticationRequestWithErrorContextData")
-    public void testInitiateAuthenticationRequestWithErrorContext(String showError, String showErrorOnLoginPage,
-                                                                  Boolean errorContextPresent, int failedAttempts,
+    public void testInitiateAuthenticationRequestWithErrorContext(boolean showError, boolean showErrorOnLoginPage,
+                                                                  boolean errorContextPresent, int failedAttempts,
                                                                   int maxAttempts, String lockedReason,
-                                                                  Boolean hasErrorCode, String errorCodeParam,
-                                                                  Boolean hasLockedReason, String lockedReasonParam)
+                                                                  boolean hasErrorCode, String errorCodeParam,
+                                                                  boolean hasLockedReason, String lockedReasonParam)
             throws AuthenticationFailedException, BackupCodeException, UserStoreException, IOException {
 
         String username = "TEST-DOMAIN/test@gmail.com";
@@ -323,10 +323,11 @@ public class BackupCodeAuthenticatorTest extends PowerMockTestCase {
 
         BackupCodeAuthenticator backupCodeAuthenticator = new BackupCodeAuthenticator();
         Map<String, String> parameterMap = new HashMap<>();
-        parameterMap.put(FrameworkConstants.SHOW_AUTHFAILURE_RESON_CONFIG, showError);
-        parameterMap.put(FrameworkConstants.SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE_CONF, showErrorOnLoginPage);
+        parameterMap.put(FrameworkConstants.SHOW_AUTHFAILURE_RESON_CONFIG, String.valueOf(showError));
+        parameterMap.put(FrameworkConstants.SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE_CONF,
+                String.valueOf(showErrorOnLoginPage));
         AuthenticatorConfig authenticatorConfig1 = new AuthenticatorConfig(
-                "backup-code-authenticator", true, parameterMap);
+                BackupCodeAuthenticatorConstants.BACKUP_CODE_AUTHENTICATOR_NAME, true, parameterMap);
         IdentityErrorMsgContext customErrorMessageContext = null;
         if (errorContextPresent) {
             customErrorMessageContext = new IdentityErrorMsgContext(
@@ -372,17 +373,17 @@ public class BackupCodeAuthenticatorTest extends PowerMockTestCase {
         String lockedErrorCode = UserCoreConstants.ErrorCode.USER_IS_LOCKED;
 
         return new Object[][]{
-                {"true", "true", true, 3, 3, "", true, "&errorCode=" + lockedErrorCode, true,
+                {true, true, true, 3, 3, "", true, "&errorCode=" + lockedErrorCode, true,
                         "&lockedReason=" + maxAttemptsExceeded},
-                {"false", "true", true, 3, 3, "", false, "errorCode", false, "lockedReason"},
-                {"true", "true", true, 0, 0, maxAttemptsExceeded, true, "&errorCode=" + lockedErrorCode, true,
+                {false, true, true, 3, 3, "", false, "errorCode", false, "lockedReason"},
+                {true, true, true, 0, 0, maxAttemptsExceeded, true, "&errorCode=" + lockedErrorCode, true,
                         "&lockedReason=" + maxAttemptsExceeded},
-                {"true", "true", true, 0, 0, adminLocked, true, "&errorCode=" + lockedErrorCode, true,
+                {true, true, true, 0, 0, adminLocked, true, "&errorCode=" + lockedErrorCode, true,
                         "&lockedReason=" + adminLocked},
-                {"true", "true", true, 0, 0, "", true, "&errorCode=" + lockedErrorCode, true,
+                {true, true, true, 0, 0, "", true, "&errorCode=" + lockedErrorCode, true,
                         "&lockedReason=" + maxAttemptsExceeded},
-                {"true", "false", true, 3, 3, "", false, "errorCode", false, "lockedReason"},
-                {"true", "true", false, 3, 3, "", false, "errorCode", false, "lockedReason"}
+                {true, false, true, 3, 3, "", false, "errorCode", false, "lockedReason"},
+                {true, true, false, 3, 3, "", false, "errorCode", false, "lockedReason"}
         };
     }
 }

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticatorTest.java
@@ -309,9 +309,9 @@ public class BackupCodeAuthenticatorTest extends PowerMockTestCase {
     }
 
     @Test(dataProvider = "initiateAuthenticationRequestWithErrorContextData")
-    public void testInitiateAuthenticationRequestWithErrorContext(String showError, Boolean errorContextPresent,
-                                                                  int failedAttempts, int maxAttempts,
-                                                                  String lockedReason,
+    public void testInitiateAuthenticationRequestWithErrorContext(String showError, String showErrorOnLoginPage,
+                                                                  Boolean errorContextPresent, int failedAttempts,
+                                                                  int maxAttempts, String lockedReason,
                                                                   Boolean hasErrorCode, String errorCodeParam,
                                                                   Boolean hasLockedReason, String lockedReasonParam)
             throws AuthenticationFailedException, BackupCodeException, UserStoreException, IOException {
@@ -322,7 +322,9 @@ public class BackupCodeAuthenticatorTest extends PowerMockTestCase {
 
         BackupCodeAuthenticator backupCodeAuthenticator = new BackupCodeAuthenticator();
         Map<String, String> parameterMap = new HashMap<>();
-        parameterMap.put(BackupCodeAuthenticatorConstants.CONF_SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE, showError);
+        parameterMap.put(BackupCodeAuthenticatorConstants.CONF_SHOW_AUTH_FAILURE_REASON, showError);
+        parameterMap.put(BackupCodeAuthenticatorConstants.CONF_SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE,
+                showErrorOnLoginPage);
         AuthenticatorConfig authenticatorConfig1 = new AuthenticatorConfig(
                 "backup-code-authenticator", true, parameterMap);
         IdentityErrorMsgContext customErrorMessageContext = null;
@@ -370,15 +372,16 @@ public class BackupCodeAuthenticatorTest extends PowerMockTestCase {
         String lockedErrorCode = UserCoreConstants.ErrorCode.USER_IS_LOCKED;
 
         return new Object[][]{
-                {"true", true, 3, 3, "", true, "&errorCode=" + lockedErrorCode, true,
+                {"true", "true", true, 3, 3, "", true, "&errorCode=" + lockedErrorCode, true,
                         "&lockedReason=" + maxAttemptsExceeded},
-                {"true", true, 0, 0, maxAttemptsExceeded, true, "&errorCode=" + lockedErrorCode, true,
+                {"false", "true", true, 3, 3, "", false, "errorCode", false, "lockedReason"},
+                {"true", "true", true, 0, 0, maxAttemptsExceeded, true, "&errorCode=" + lockedErrorCode, true,
                         "&lockedReason=" + maxAttemptsExceeded},
-                {"true", true, 0, 0, adminLocked, true, "&errorCode=" + lockedErrorCode, true,
+                {"true", "true", true, 0, 0, adminLocked, true, "&errorCode=" + lockedErrorCode, true,
                         "&lockedReason=" + adminLocked},
-                {"true", true, 0, 0, "", true, "&errorCode=" + lockedErrorCode, false, "lockedReason"},
-                {"false", true, 3, 3, "", false, "errorCode", false, "lockedReason"},
-                {"true", false, 3, 3, "", false, "errorCode", false, "lockedReason"}
+                {"true", "true", true, 0, 0, "", true, "&errorCode=" + lockedErrorCode, false, "lockedReason"},
+                {"true", "false", true, 3, 3, "", false, "errorCode", false, "lockedReason"},
+                {"true", "true", false, 3, 3, "", false, "errorCode", false, "lockedReason"}
         };
     }
 }

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticatorTest.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.identity.application.authentication.framework.context.Aut
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.LogoutFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants;
 import org.wso2.carbon.identity.application.authenticator.backupcode.exception.BackupCodeException;
 import org.wso2.carbon.identity.application.authenticator.backupcode.internal.BackupCodeDataHolder;
@@ -223,7 +224,7 @@ public class BackupCodeAuthenticatorTest extends PowerMockTestCase {
 
         BackupCodeAuthenticator backupCodeAuthenticator = new BackupCodeAuthenticator();
         Map<String, String> parameterMap = new HashMap<>();
-        parameterMap.put(BackupCodeAuthenticatorConstants.CONF_SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE, "false");
+        parameterMap.put(FrameworkConstants.SHOW_AUTHFAILURE_RESON_CONFIG, "false");
         AuthenticatorConfig authenticatorConfig = new AuthenticatorConfig(
                 "backup-code-authenticator", true, parameterMap);
         try {
@@ -322,9 +323,8 @@ public class BackupCodeAuthenticatorTest extends PowerMockTestCase {
 
         BackupCodeAuthenticator backupCodeAuthenticator = new BackupCodeAuthenticator();
         Map<String, String> parameterMap = new HashMap<>();
-        parameterMap.put(BackupCodeAuthenticatorConstants.CONF_SHOW_AUTH_FAILURE_REASON, showError);
-        parameterMap.put(BackupCodeAuthenticatorConstants.CONF_SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE,
-                showErrorOnLoginPage);
+        parameterMap.put(FrameworkConstants.SHOW_AUTHFAILURE_RESON_CONFIG, showError);
+        parameterMap.put(FrameworkConstants.SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE_CONF, showErrorOnLoginPage);
         AuthenticatorConfig authenticatorConfig1 = new AuthenticatorConfig(
                 "backup-code-authenticator", true, parameterMap);
         IdentityErrorMsgContext customErrorMessageContext = null;
@@ -379,7 +379,8 @@ public class BackupCodeAuthenticatorTest extends PowerMockTestCase {
                         "&lockedReason=" + maxAttemptsExceeded},
                 {"true", "true", true, 0, 0, adminLocked, true, "&errorCode=" + lockedErrorCode, true,
                         "&lockedReason=" + adminLocked},
-                {"true", "true", true, 0, 0, "", true, "&errorCode=" + lockedErrorCode, false, "lockedReason"},
+                {"true", "true", true, 0, 0, "", true, "&errorCode=" + lockedErrorCode, true,
+                        "&lockedReason=" + maxAttemptsExceeded},
                 {"true", "false", true, 3, 3, "", false, "errorCode", false, "lockedReason"},
                 {"true", "true", false, 3, 3, "", false, "errorCode", false, "lockedReason"}
         };

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticatorTest.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.application.authenticator.backupcode;
 import org.apache.axis2.context.ConfigurationContext;
 import org.apache.axis2.engine.AxisConfiguration;
 import org.mockito.Mock;
+import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.api.support.membermodification.MemberMatcher;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -30,25 +31,32 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.extension.identity.helper.FederatedAuthenticatorUtil;
 import org.wso2.carbon.identity.application.authentication.framework.AbstractApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorFlowStatus;
+import org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.LogoutFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants;
 import org.wso2.carbon.identity.application.authenticator.backupcode.exception.BackupCodeException;
 import org.wso2.carbon.identity.application.authenticator.backupcode.internal.BackupCodeDataHolder;
 import org.wso2.carbon.identity.application.authenticator.backupcode.util.BackupCodeUtil;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.JustInTimeProvisioningConfig;
 import org.wso2.carbon.identity.core.internal.IdentityCoreServiceComponent;
+import org.wso2.carbon.identity.core.model.IdentityErrorMsgContext;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.IdpManager;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
+import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.utils.CarbonUtils;
 import org.wso2.carbon.utils.ConfigurationContextService;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -59,6 +67,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
@@ -73,6 +82,7 @@ import static org.wso2.carbon.identity.application.authenticator.backupcode.cons
 import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.IS_INITIAL_FEDERATED_USER_ATTEMPT;
 
 @PrepareForTest({BackupCodeAuthenticator.class, BackupCodeUtil.class, BackupCodeDataHolder.class,
+        FileBasedConfigurationBuilder.class, IdentityUtil.class,
         FederatedAuthenticatorUtil.class, IdentityCoreServiceComponent.class, CarbonUtils.class})
 public class BackupCodeAuthenticatorTest extends PowerMockTestCase {
 
@@ -111,12 +121,17 @@ public class BackupCodeAuthenticatorTest extends PowerMockTestCase {
 
     @Mock
     AxisConfiguration mockAxisConfiguration;
+
+    @Mock
+    FileBasedConfigurationBuilder fileBasedConfigurationBuilder;
+
     private static final String VALID_TOKEN = "234561";
     private static final String INVALID_TOKEN = "123456";
     private static final String FULL_QUALIFIED_USERNAME = "TEST-DOMAIN/test@gmail.com@carbon.super";
     private static final String HASHED_BACKUP_CODES =
             "2d578fa2a67a4e24933164a78752f9ea60cdbcbcb683637b582595e49d19a305,2dc0269fa54d269a87536810ec453cb095b4b92f45e63826a21dff1c2e76f169";
     private static final String TENANT_DOMAIN = "carbon.super";
+    private String redirect;
 
     @Test(dataProvider = "canHandleData")
     public void testCanHandle(String backupCode, boolean expectedValue) {
@@ -207,12 +222,17 @@ public class BackupCodeAuthenticatorTest extends PowerMockTestCase {
                             boolean expectError) throws BackupCodeException, UserStoreException {
 
         BackupCodeAuthenticator backupCodeAuthenticator = new BackupCodeAuthenticator();
+        Map<String, String> parameterMap = new HashMap<>();
+        parameterMap.put(BackupCodeAuthenticatorConstants.CONF_SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE, "false");
+        AuthenticatorConfig authenticatorConfig = new AuthenticatorConfig(
+                "backup-code-authenticator", true, parameterMap);
         try {
             mockStatic(BackupCodeUtil.class);
             mockStatic(FederatedAuthenticatorUtil.class);
             mockStatic(BackupCodeDataHolder.class);
             mockStatic(IdentityCoreServiceComponent.class);
             mockStatic(CarbonUtils.class);
+            mockStatic(FileBasedConfigurationBuilder.class);
             when(mockAuthenticationContext.isLogoutRequest()).thenReturn(isLogoutRequest);
             when(mockAuthenticationContext.getTenantDomain()).thenReturn(TENANT_DOMAIN);
             when(mockAuthenticationContext.getProperty(AUTHENTICATION)).thenReturn(authenticatorName);
@@ -245,7 +265,9 @@ public class BackupCodeAuthenticatorTest extends PowerMockTestCase {
             when(CarbonUtils.getTransportProxyPort((AxisConfiguration) anyObject(), anyString())).thenReturn(9443);
             when(FederatedAuthenticatorUtil.getLocalUsernameAssociatedWithFederatedUser(anyString(), any())).thenReturn(
                     username);
-            suppress(MemberMatcher.methodsDeclaredIn(AbstractApplicationAuthenticator.class));
+            when(FileBasedConfigurationBuilder.getInstance()).thenReturn(fileBasedConfigurationBuilder);
+            when(fileBasedConfigurationBuilder.getAuthenticatorBean(anyString())).thenReturn(authenticatorConfig);
+
             AuthenticatorFlowStatus flowStatus =
                     backupCodeAuthenticator.process(mockHttpServletRequest, mocHttpServletResponse,
                             mockAuthenticationContext);
@@ -283,6 +305,80 @@ public class BackupCodeAuthenticatorTest extends PowerMockTestCase {
                         AuthenticatorFlowStatus.INCOMPLETE, false},
                 {false, null, "backup-code-authenticator", false, "test@gmail.com", false, new HashMap<>(), true, true,
                         AuthenticatorFlowStatus.INCOMPLETE, false}
+        };
+    }
+
+    @Test(dataProvider = "initiateAuthenticationRequestWithErrorContextData")
+    public void testInitiateAuthenticationRequestWithErrorContext(String showError, Boolean errorContextPresent,
+                                                                  int failedAttempts, int maxAttempts,
+                                                                  String lockedReason,
+                                                                  Boolean hasErrorCode, String errorCodeParam,
+                                                                  Boolean hasLockedReason, String lockedReasonParam)
+            throws AuthenticationFailedException, BackupCodeException, UserStoreException, IOException {
+
+        String username = "TEST-DOMAIN/test@gmail.com";
+        Map<String, String> claims = new HashMap<>();
+        claims.put(BACKUP_CODES_CLAIM, HASHED_BACKUP_CODES);
+
+        BackupCodeAuthenticator backupCodeAuthenticator = new BackupCodeAuthenticator();
+        Map<String, String> parameterMap = new HashMap<>();
+        parameterMap.put(BackupCodeAuthenticatorConstants.CONF_SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE, showError);
+        AuthenticatorConfig authenticatorConfig1 = new AuthenticatorConfig(
+                "backup-code-authenticator", true, parameterMap);
+        IdentityErrorMsgContext customErrorMessageContext = null;
+        if (errorContextPresent) {
+            customErrorMessageContext = new IdentityErrorMsgContext(
+                    UserCoreConstants.ErrorCode.USER_IS_LOCKED + ":" + lockedReason,
+                    failedAttempts, maxAttempts);
+        }
+
+        mockStatic(FileBasedConfigurationBuilder.class);
+        mockStatic(BackupCodeUtil.class);
+        mockStatic(FederatedAuthenticatorUtil.class);
+        mockStatic(IdentityUtil.class);
+        when(BackupCodeUtil.getUserStoreManagerOfUser(anyString())).thenReturn(mockUserStoreManager);
+        when(FileBasedConfigurationBuilder.getInstance()).thenReturn(fileBasedConfigurationBuilder);
+        when(fileBasedConfigurationBuilder.getAuthenticatorBean(anyString())).thenReturn(authenticatorConfig1);
+        when(mockAuthenticationContext.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+        when(BackupCodeUtil.getAuthenticatedUser(any())).thenReturn(mockAuthenticatedUser);
+        when(mockAuthenticatedUser.getUserName()).thenReturn(username);
+        when(mockUserStoreManager.getUserClaimValues(anyString(), anyObject(), anyString())).thenReturn(claims);
+        when(IdentityUtil.getIdentityErrorMsg()).thenReturn(customErrorMessageContext);
+        when(mockAuthenticatedUser.isFederatedUser()).thenReturn(false);
+        when(BackupCodeUtil.getBackupCodeLoginPage(anyObject())).thenReturn(
+                "https://localhost:9443/authenticationendpoint/backup_code.do");
+        when(BackupCodeUtil.getBackupCodeErrorPage(anyObject())).thenReturn(
+                "https://localhost:9443/authenticationendpoint/backup_code_error.do");
+        doAnswer((Answer<Object>) invocation -> {
+
+            redirect = (String) invocation.getArguments()[0];
+            return null;
+        }).when(mocHttpServletResponse).sendRedirect(anyString());
+
+        backupCodeAuthenticator.initiateAuthenticationRequest(mockHttpServletRequest, mocHttpServletResponse,
+                mockAuthenticationContext);
+
+        assertFalse(hasErrorCode ^ redirect.contains(errorCodeParam));
+        assertFalse(hasLockedReason ^ redirect.contains(lockedReasonParam));
+    }
+
+    @DataProvider(name="initiateAuthenticationRequestWithErrorContextData")
+    public Object[][] DataForInitiateAuthenticationRequestWithErrorContext() {
+
+        String maxAttemptsExceeded = BackupCodeAuthenticatorConstants.MAX_ATTEMPTS_EXCEEDED;
+        String adminLocked = BackupCodeAuthenticatorConstants.ADMIN_INITIATED;
+        String lockedErrorCode = UserCoreConstants.ErrorCode.USER_IS_LOCKED;
+
+        return new Object[][]{
+                {"true", true, 3, 3, "", true, "&errorCode=" + lockedErrorCode, true,
+                        "&lockedReason=" + maxAttemptsExceeded},
+                {"true", true, 0, 0, maxAttemptsExceeded, true, "&errorCode=" + lockedErrorCode, true,
+                        "&lockedReason=" + maxAttemptsExceeded},
+                {"true", true, 0, 0, adminLocked, true, "&errorCode=" + lockedErrorCode, true,
+                        "&lockedReason=" + adminLocked},
+                {"true", true, 0, 0, "", true, "&errorCode=" + lockedErrorCode, false, "lockedReason"},
+                {"false", true, 3, 3, "", false, "errorCode", false, "lockedReason"},
+                {"true", false, 3, 3, "", false, "errorCode", false, "lockedReason"}
         };
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <carbon.commons.version>4.4.8</carbon.commons.version>
         <carbon.commons.imp.pkg.version>[4.4.0, 5.0.0)</carbon.commons.imp.pkg.version>
         <!--Carbon identity version-->
-        <carbon.identity.framework.version>5.20.320</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.21</carbon.identity.framework.version>
 
         <carbon.identity.version>5.0.7</carbon.identity.version>
         <carbon.identity.package.export.version>${carbon.identity.version}</carbon.identity.package.export.version>


### PR DESCRIPTION
## Purpose
This PR adds support to send errorcode when an account is locked with locked reason for Backup Code authenticator.
This is enabled with the following configuration
```
[authentication.authenticator.backup_code.parameters]
showAuthFailureReason = true
showAuthFailureReasonOnLoginPage = true
```

## Related PRs
- 