### PR TITLE
Get login tenant domain as tenantDomain

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
@@ -158,7 +158,7 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
                                                  AuthenticationContext context) throws AuthenticationFailedException {
 
         String username = null;
-        String tenantDomain = context.getTenantDomain();
+        String tenantDomain = context.getLoginTenantDomain();
         context.setProperty(AUTHENTICATION, BACKUP_CODE_AUTHENTICATOR_NAME);
         if (!tenantDomain.equals(SUPER_TENANT_DOMAIN)) {
             IdentityHelperUtil.loadApplicationAuthenticationXMLFromRegistry(context, getName(), tenantDomain);

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticatorTest.java
@@ -235,7 +235,7 @@ public class BackupCodeAuthenticatorTest extends PowerMockTestCase {
             mockStatic(CarbonUtils.class);
             mockStatic(FileBasedConfigurationBuilder.class);
             when(mockAuthenticationContext.isLogoutRequest()).thenReturn(isLogoutRequest);
-            when(mockAuthenticationContext.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+            when(mockAuthenticationContext.getLoginTenantDomain()).thenReturn(TENANT_DOMAIN);
             when(mockAuthenticationContext.getProperty(AUTHENTICATION)).thenReturn(authenticatorName);
             when(mockAuthenticationContext.isRetrying()).thenReturn(isRetrying);
             when(mockHttpServletRequest.getParameter(BACKUP_CODE)).thenReturn(backupCode);
@@ -342,7 +342,7 @@ public class BackupCodeAuthenticatorTest extends PowerMockTestCase {
         when(BackupCodeUtil.getUserStoreManagerOfUser(anyString())).thenReturn(mockUserStoreManager);
         when(FileBasedConfigurationBuilder.getInstance()).thenReturn(fileBasedConfigurationBuilder);
         when(fileBasedConfigurationBuilder.getAuthenticatorBean(anyString())).thenReturn(authenticatorConfig1);
-        when(mockAuthenticationContext.getTenantDomain()).thenReturn(TENANT_DOMAIN);
+        when(mockAuthenticationContext.getLoginTenantDomain()).thenReturn(TENANT_DOMAIN);
         when(BackupCodeUtil.getAuthenticatedUser(any())).thenReturn(mockAuthenticatedUser);
         when(mockAuthenticatedUser.getUserName()).thenReturn(username);
         when(mockUserStoreManager.getUserClaimValues(anyString(), anyObject(), anyString())).thenReturn(claims);


### PR DESCRIPTION
## Purpose
Get the login tenant domain as the tenant domain for the initial authentication request instead of the `getTenantDomain()` method for the correct behavior. 