### PR TITLE
Add diagnostic logs to the backup code authenticator

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -244,7 +244,7 @@
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.55</minimum>
+                                            <minimum>0.60</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -81,6 +81,10 @@
             <artifactId>encoder</artifactId>
             <version>${encoder.wso2.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+        </dependency>
 
         <!--Test Dependencies-->
         <dependency>
@@ -142,6 +146,7 @@
                             org.apache.commons.logging.*;version="${commons-logging.osgi.version.range}",
                             org.osgi.framework.*; version="${osgi.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.*;version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.central.log.mgt.utils; version="${carbon.identity.package.import.version.range}",
                             javax.servlet;version="${imp.pkg.version.javax.servlet}",
                             javax.servlet.http;version="${imp.pkg.version.javax.servlet}",
                             org.wso2.carbon.identity.core.*; version="${carbon.identity.package.import.version.range}",
@@ -239,7 +244,7 @@
                                         <limit implementation="org.jacoco.report.check.Limit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.60</minimum>
+                                            <minimum>0.55</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -84,6 +84,7 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <!--Test Dependencies-->

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
@@ -177,7 +177,7 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
         if (LoggerUtils.isDiagnosticLogsEnabled()) {
             DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
                     BACKUP_CODE_AUTH_SERVICE, INITIATE_BACKUP_CODE_REQUEST);
-            diagnosticLogBuilder.resultMessage("Initiate backup code authentication request.")
+            diagnosticLogBuilder.resultMessage("Initiating backup code authentication request.")
                     .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
                     .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
                     .inputParam(LogConstants.InputKeys.STEP, context.getCurrentStep())

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
@@ -848,7 +848,7 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
                 return Optional.ofNullable(authenticatedUser.getUserId());
             }
         } catch (UserIdNotFoundException e) {
-                log.debug("Error while getting the user id from the authenticated user.", e);
+            log.debug("Error while getting the user id from the authenticated user.", e);
         }
         return Optional.empty();
     }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
@@ -87,8 +87,8 @@ import static org.wso2.carbon.identity.application.authenticator.backupcode.cons
 import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.ErrorMessages.ERROR_NO_FEDERATED_USER;
 import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.ErrorMessages.ERROR_GETTING_THE_USER_STORE_MANAGER;
 import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.IS_INITIAL_FEDERATED_USER_ATTEMPT;
+import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.LogConstants.ActionIDs.INITIATE_BACKUP_CODE_REQUEST;
 import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.LogConstants.ActionIDs.PROCESS_AUTHENTICATION_RESPONSE;
-import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.LogConstants.ActionIDs.VALIDATE_BACKUP_CODE_REQUEST;
 import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.LogConstants.BACKUP_CODE_AUTH_SERVICE;
 import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.SUPER_TENANT_DOMAIN;
 import static org.wso2.carbon.identity.event.IdentityEventConstants.Event.POST_NON_BASIC_AUTHENTICATION;
@@ -176,8 +176,8 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
 
         if (LoggerUtils.isDiagnosticLogsEnabled()) {
             DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
-                    BACKUP_CODE_AUTH_SERVICE, VALIDATE_BACKUP_CODE_REQUEST);
-            diagnosticLogBuilder.resultMessage("Validate backup code authentication request.")
+                    BACKUP_CODE_AUTH_SERVICE, INITIATE_BACKUP_CODE_REQUEST);
+            diagnosticLogBuilder.resultMessage("Initiate backup code authentication request.")
                     .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
                     .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
                     .inputParam(LogConstants.InputKeys.STEP, context.getCurrentStep())
@@ -253,7 +253,7 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
             DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = null;
             if (LoggerUtils.isDiagnosticLogsEnabled()) {
                 diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(BACKUP_CODE_AUTH_SERVICE,
-                        VALIDATE_BACKUP_CODE_REQUEST);
+                        INITIATE_BACKUP_CODE_REQUEST);
                 diagnosticLogBuilder.inputParams(getApplicationDetails(context))
                         .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
                         .inputParam(LogConstants.InputKeys.STEP, context.getCurrentStep())
@@ -815,7 +815,8 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
         }
     }
 
-    /** Add application details to a map.
+    /**
+     * Add application details to a map.
      *
      * @param context AuthenticationContext.
      * @return Map with application details.
@@ -847,9 +848,7 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
                 return Optional.ofNullable(authenticatedUser.getUserId());
             }
         } catch (UserIdNotFoundException e) {
-            if (log.isDebugEnabled()) {
                 log.debug("Error while getting the user id from the authenticated user.", e);
-            }
         }
         return Optional.empty();
     }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
@@ -268,7 +268,7 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
                 String backupCodeLoginPageUrl =
                         buildBackupCodeLoginPageURL(context, username, retryParam, errorParam, multiOptionURI);
                 response.sendRedirect(backupCodeLoginPageUrl);
-                if (LoggerUtils.isDiagnosticLogsEnabled() && diagnosticLogBuilder != null) {
+                if (diagnosticLogBuilder != null) {
                     diagnosticLogBuilder.resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
                             .resultMessage("Redirecting to backup code login page.")
                             .resultStatus(DiagnosticLog.ResultStatus.SUCCESS);
@@ -278,7 +278,7 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
                 String backupCodeErrorPageUrl =
                         buildBackupCodeErrorPageURL(context, username, retryParam, errorParam, multiOptionURI);
                 response.sendRedirect(backupCodeErrorPageUrl);
-                if (LoggerUtils.isDiagnosticLogsEnabled() && diagnosticLogBuilder != null) {
+                if (diagnosticLogBuilder != null) {
                     diagnosticLogBuilder.resultStatus(DiagnosticLog.ResultStatus.FAILED)
                             .resultMessage("Redirecting to backup code error page.");
                     LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/constants/BackupCodeAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/constants/BackupCodeAuthenticatorConstants.java
@@ -64,7 +64,7 @@ public class BackupCodeAuthenticatorConstants {
         public static class ActionIDs {
 
             public static final String PROCESS_AUTHENTICATION_RESPONSE = "process-backupcode-authentication-response";
-            public static final String VALIDATE_BACKUP_CODE_REQUEST = "validate-backupcode-authentication-request";
+            public static final String INITIATE_BACKUP_CODE_REQUEST = "initiate-backupcode-authentication-request";
         }
     }
 

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/constants/BackupCodeAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/constants/BackupCodeAuthenticatorConstants.java
@@ -51,6 +51,23 @@ public class BackupCodeAuthenticatorConstants {
     public static final String MAX_ATTEMPTS_EXCEEDED = "MAX_ATTEMPTS_EXCEEDED";
     public static final String ADMIN_INITIATED = "ADMIN_INITIATED";
 
+    /**
+     * Constants related to log management.
+     */
+    public static class LogConstants {
+
+        public static final String BACKUP_CODE_AUTH_SERVICE = "local-auth-backupcode";
+
+        /**
+         * Define action IDs for diagnostic logs.
+         */
+        public static class ActionIDs {
+
+            public static final String PROCESS_AUTHENTICATION_RESPONSE = "process-backupcode-authentication-response";
+            public static final String VALIDATE_BACKUP_CODE_REQUEST = "validate-backupcode-authentication-request";
+        }
+    }
+
     public enum ErrorMessages {
 
         ERROR_NO_USERNAME("60001", "Username cannot be empty"),

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticatorTest.java
@@ -23,19 +23,19 @@ import org.apache.axis2.engine.AxisConfiguration;
 import org.mockito.Mock;
 import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
-import org.powermock.api.support.membermodification.MemberMatcher;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.extension.identity.helper.FederatedAuthenticatorUtil;
-import org.wso2.carbon.identity.application.authentication.framework.AbstractApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorFlowStatus;
 import org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.LogoutFailedException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants;
@@ -44,6 +44,7 @@ import org.wso2.carbon.identity.application.authenticator.backupcode.internal.Ba
 import org.wso2.carbon.identity.application.authenticator.backupcode.util.BackupCodeUtil;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.application.common.model.JustInTimeProvisioningConfig;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.internal.IdentityCoreServiceComponent;
 import org.wso2.carbon.identity.core.model.IdentityErrorMsgContext;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
@@ -60,6 +61,7 @@ import org.wso2.carbon.utils.ConfigurationContextService;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -69,10 +71,9 @@ import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.support.membermodification.MemberModifier.suppress;
+import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
@@ -84,7 +85,7 @@ import static org.wso2.carbon.identity.application.authenticator.backupcode.cons
 
 @PrepareForTest({BackupCodeAuthenticator.class, BackupCodeUtil.class, BackupCodeDataHolder.class,
         FileBasedConfigurationBuilder.class, IdentityUtil.class,
-        FederatedAuthenticatorUtil.class, IdentityCoreServiceComponent.class, CarbonUtils.class})
+        FederatedAuthenticatorUtil.class, IdentityCoreServiceComponent.class, CarbonUtils.class, LoggerUtils.class})
 public class BackupCodeAuthenticatorTest extends PowerMockTestCase {
 
     @Mock
@@ -129,10 +130,19 @@ public class BackupCodeAuthenticatorTest extends PowerMockTestCase {
     private static final String VALID_TOKEN = "234561";
     private static final String INVALID_TOKEN = "123456";
     private static final String FULL_QUALIFIED_USERNAME = "TEST-DOMAIN/test@gmail.com@carbon.super";
+    private static final String USERNAME = "test@gmail.com";
+    private static final String USER_ID = UUID.randomUUID().toString();
     private static final String HASHED_BACKUP_CODES =
             "2d578fa2a67a4e24933164a78752f9ea60cdbcbcb683637b582595e49d19a305,2dc0269fa54d269a87536810ec453cb095b4b92f45e63826a21dff1c2e76f169";
     private static final String TENANT_DOMAIN = "carbon.super";
     private String redirect;
+
+    @BeforeMethod
+    public void setUp() {
+
+        mockStatic(LoggerUtils.class);
+        when(LoggerUtils.isDiagnosticLogsEnabled()).thenReturn(true);
+    }
 
     @Test(dataProvider = "canHandleData")
     public void testCanHandle(String backupCode, boolean expectedValue) {
@@ -163,16 +173,19 @@ public class BackupCodeAuthenticatorTest extends PowerMockTestCase {
     }
 
     @Test(dataProvider = "processAuthenticationResponseData")
-    public void testProcessAuthenticationResponse(String token, String fullyQualifiedUserName, boolean isLocalUser,
-                                                  boolean isAccountLock, boolean isInitialFedAttempt,
-                                                  Map<String, String> claims, boolean expectError)
-            throws IdentityEventException, UserStoreException {
+    public void testProcessAuthenticationResponse(String token, String fullyQualifiedUserName, String username,
+                                                  String userId, boolean isLocalUser, boolean isAccountLock,
+                                                  boolean isInitialFedAttempt, Map<String, String> claims,
+                                                  boolean expectError)
+            throws IdentityEventException, UserStoreException, UserIdNotFoundException {
 
         mockStatic(BackupCodeUtil.class, CALLS_REAL_METHODS);
         mockStatic(BackupCodeDataHolder.class);
         when(mockHttpServletRequest.getParameter(BACKUP_CODE)).thenReturn(token);
         when(mockAuthenticationContext.getProperty(AUTHENTICATED_USER)).thenReturn(mockAuthenticatedUser);
         when(mockAuthenticatedUser.toFullQualifiedUsername()).thenReturn(fullyQualifiedUserName);
+        when(mockAuthenticatedUser.getUserName()).thenReturn(username);
+        when(mockAuthenticatedUser.getUserId()).thenReturn(userId);
         try {
             PowerMockito.doReturn(isLocalUser).when(BackupCodeUtil.class, "isLocalUser", mockAuthenticationContext);
             PowerMockito.doReturn(isAccountLock)
@@ -208,12 +221,12 @@ public class BackupCodeAuthenticatorTest extends PowerMockTestCase {
 
         Map<String, String> claims = new HashMap<>();
         claims.put(BACKUP_CODES_CLAIM, HASHED_BACKUP_CODES);
-        return new Object[][]{{VALID_TOKEN, FULL_QUALIFIED_USERNAME, true, false, false, claims, false},
-                {INVALID_TOKEN, FULL_QUALIFIED_USERNAME, true, false, false, claims, true},
-                {VALID_TOKEN, FULL_QUALIFIED_USERNAME, false, false, true, claims, false},
-                {VALID_TOKEN, FULL_QUALIFIED_USERNAME, true, true, false, claims, true},
-                {VALID_TOKEN, FULL_QUALIFIED_USERNAME, true, false, false, new HashMap<>(), true},
-                {"", FULL_QUALIFIED_USERNAME, true, false, false, new HashMap<>(), true}};
+        return new Object[][]{{VALID_TOKEN, FULL_QUALIFIED_USERNAME, USERNAME, null, true, false, false, claims, false},
+                {INVALID_TOKEN, FULL_QUALIFIED_USERNAME, USERNAME, USER_ID, true, false, false, claims, true},
+                {VALID_TOKEN, FULL_QUALIFIED_USERNAME, USERNAME, USER_ID, false, false, true, claims, false},
+                {VALID_TOKEN, FULL_QUALIFIED_USERNAME, USERNAME, USER_ID, true, true, false, claims, true},
+                {VALID_TOKEN, FULL_QUALIFIED_USERNAME, USERNAME, USER_ID, true, false, false, new HashMap<>(), true},
+                {"", FULL_QUALIFIED_USERNAME, USERNAME, null, true, false, false, new HashMap<>(), true}};
     }
 
     @Test(dataProvider = "processData")

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,11 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.event.handler.accountlock</groupId>
                 <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
                 <version>${carbon.identity.account.lock.handler.version}</version>
@@ -102,6 +107,11 @@
                         <artifactId>log4j-over-slf4j</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+                <version>${org.wso2.carbon.identity.organization.management.core.version}</version>
             </dependency>
 
             <!--Test Dependencies-->
@@ -133,7 +143,7 @@
     </dependencyManagement>
 
     <properties>
-        <carbon.kernel.version>4.7.0</carbon.kernel.version>
+        <carbon.kernel.version>4.9.10</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.4.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.kernel.registry.imp.pkg.version>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version>
         <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>
@@ -144,7 +154,10 @@
         <carbon.commons.version>4.4.8</carbon.commons.version>
         <carbon.commons.imp.pkg.version>[4.4.0, 5.0.0)</carbon.commons.imp.pkg.version>
         <!--Carbon identity version-->
-        <carbon.identity.framework.version>5.25.21</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.260</carbon.identity.framework.version>
+
+        <org.wso2.carbon.identity.organization.management.core.version>1.0.0
+        </org.wso2.carbon.identity.organization.management.core.version>
 
         <carbon.identity.version>5.0.7</carbon.identity.version>
         <carbon.identity.package.export.version>${carbon.identity.version}</carbon.identity.package.export.version>

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
                 <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
                 <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
                 <version>${org.wso2.carbon.identity.organization.management.core.version}</version>
+                <scope>test</scope>
             </dependency>
 
             <!--Test Dependencies-->


### PR DESCRIPTION
## Purpose
$subject

### Approach

![image](https://github.com/wso2-enterprise/asgardeo-product/assets/32576163/ceea5959-581e-47aa-b7b2-6962861a2b2d)

Diagnostic logs will be covered the green-colored actions/validations of the authentication process. 
1. Authentication Request Validation
Within each authenticator, the `initiateAuthenticationRequest` method houses the logic for this step. This triggers two diagnostic logs. The first log indicates when authentication validation starts, and the second log shows the result of the validation – whether it's a Success or marked Invalid.

2. Validate Authentication Response
The `processAuthenticationResponse` method handles authentication response validation. Once users are sent to the authentication page and complete the process, the authenticator receives an authentication response, which this method manages. Just like the request validation, this step also generates two diagnostic logs. The first one marks the beginning of response validation, while the second one is only created if the authentication is successful. We've chosen not to include logs for authentication response failures for a couple of reasons:
- Numerous potential failure scenarios across authenticators make adding logs for each too complicated and code-heavy.
- With https://github.com/wso2/carbon-identity-framework/pull/4809, there's a common log in place that covers and reports authentication response failures caused by authenticators.

Additionally, there will be another diagnostic log that will get published from the canHandle() method of the authenticator. The `canHandle` method gets executed each time before the `initiateAuthenticationRequest` and `processAuthenticationResponse` get executed. This log is published as an internal log for our internal developers. The purpose of this log is to verify whether the auth request/response was passed into the authenticator to handle it.