### PR TITLE
Add sp and t params when build login page url.

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
@@ -541,11 +541,35 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
                                                String errorParam, String multiOptionURI)
             throws AuthenticationFailedException, URISyntaxException, URLBuilderException {
 
+        Map<String, String> queryParams = extractQueryParamsFromContext(context);
         String queryString = "sessionDataKey=" + context.getContextIdentifier() + "&authenticators=" + getName() +
-                "&type=backup-code" + retryParam + "&username=" + username + errorParam + multiOptionURI;
+                "&type=backup-code" + retryParam + "&username=" + username + errorParam;
+
+        if (queryParams.containsKey("t")) {
+            queryString = queryString + "&t=" + queryParams.get("t");
+        }
+
+        if (queryParams.containsKey("sp")) {
+            queryString = queryString + "&sp=" + queryParams.get("sp");
+        }
+
+        queryString = queryString + multiOptionURI;
         String loginPage = FrameworkUtils.appendQueryParamsStringToUrl(BackupCodeUtil.getBackupCodeLoginPage(context),
                 queryString);
         return buildAbsoluteURL(loginPage);
+    }
+
+    private Map<String, String> extractQueryParamsFromContext(AuthenticationContext context) {
+
+        Map<String, String> parameters = new HashMap<>();
+        String[] keyValuePairs = context.getQueryParams().split("&");
+        for (String pair : keyValuePairs) {
+            String[] keyValue = pair.split("=");
+            if (keyValue.length == 2) {
+                parameters.put(keyValue[0], keyValue[1]);
+            }
+        }
+        return parameters;
     }
 
     private String buildErrorParamString(Map<String, String> paramMap) {


### PR DESCRIPTION
## Purpose
Added the query params `t` which contains the tenant domain of the application and `sp` which contains the name of the application when building the login page url. These params ar required to enable custom branding in the backup code authentication page.