### PR TITLE
Set missing display name property to Auth Initiation Data

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticator.java
@@ -927,6 +927,7 @@ public class BackupCodeAuthenticator extends AbstractApplicationAuthenticator im
 
         AuthenticatorData authenticatorData = new AuthenticatorData();
         authenticatorData.setName(getName());
+        authenticatorData.setDisplayName(getFriendlyName());
         String idpName = null;
 
         if (context != null && context.getExternalIdP() != null) {

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAuthenticatorTest.java
@@ -539,6 +539,8 @@ public class BackupCodeAuthenticatorTest extends PowerMockTestCase {
             AuthenticatorParamMetadata expectedParam = authenticatorParamMetadataList.get(i);
             AuthenticatorParamMetadata actualParam = authenticatorDataObj.getAuthParams().get(i);
             Assert.assertEquals(actualParam.getName(), expectedParam.getName(), "Parameter name should match.");
+            Assert.assertEquals(actualParam.getDisplayName(), expectedParam.getDisplayName(),
+                    "Parameter display name should match.");
             Assert.assertEquals(actualParam.getType(), expectedParam.getType(), "Parameter type should match.");
             Assert.assertEquals(actualParam.getParamOrder(), expectedParam.getParamOrder(),
                     "Parameter order should match.");


### PR DESCRIPTION
Fixes the issue of not having the display name property in the auth initiation data during api based autehntication.

Related issue: https://github.com/wso2/product-is/issues/20219