### PR TITLE
Introduce new backup code mgt services using userid

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAPIHandler.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAPIHandler.java
@@ -20,8 +20,22 @@ package org.wso2.carbon.identity.application.authenticator.backupcode;
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.application.authenticator.backupcode.exception.BackupCodeClientException;
 import org.wso2.carbon.identity.application.authenticator.backupcode.exception.BackupCodeException;
+import org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants;
 import org.wso2.carbon.identity.application.authenticator.backupcode.util.BackupCodeUtil;
+import org.wso2.carbon.CarbonConstants;
+import org.wso2.carbon.context.CarbonContext;
+import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.UniqueIDUserStoreManager;
+import org.wso2.carbon.user.core.UserStoreClientException;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
+import org.wso2.carbon.utils.AuditLog;
+import org.wso2.carbon.utils.DiagnosticLog;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.util.ArrayList;
@@ -30,11 +44,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.BACKUP_CODE_AUTHENTICATOR_NAME;
 import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.Claims.BACKUP_CODES_CLAIM;
 import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.Claims.BACKUP_CODES_ENABLED_CLAIM;
+import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.Claims.ENABLED_AUTHENTICATORS_CLAIM;
 import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.ErrorMessages.ERROR_ACCESS_USER_REALM;
+import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.ErrorMessages.ERROR_BACKUP_CODE_UPDATE_FAILURE;
+import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.ErrorMessages.ERROR_NO_USER_ID;
 import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.ErrorMessages.ERROR_SETTING_USER_CLAIM_VALUES;
 import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.ErrorMessages.ERROR_NO_USERNAME;
+import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.LogConstants.ActionIDs.DELETE_BACKUP_CODES;
+import static org.wso2.carbon.identity.application.authenticator.backupcode.constants.BackupCodeAuthenticatorConstants.LogConstants.ActionIDs.GENERATE_BACKUP_CODES;
+import static org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils.triggerAuditLogEvent;
 
 /**
  * Handle backup code API related functionalities.
@@ -42,6 +63,42 @@ import static org.wso2.carbon.identity.application.authenticator.backupcode.cons
 public class BackupCodeAPIHandler {
 
     private static final String BACKUP_CODE_SEPARATOR = ",";
+
+    private static String getAuditInitiatorId() {
+
+        String user = CarbonContext.getThreadLocalCarbonContext().getUsername();
+        if (StringUtils.isNotBlank(user)) {
+            user = UserCoreUtil.addTenantDomainToEntry(user,
+                    CarbonContext.getThreadLocalCarbonContext().getTenantDomain());
+        } else {
+            user = CarbonConstants.REGISTRY_SYSTEM_USERNAME;
+        }
+        String initiator = null;
+        String username = MultitenantUtils.getTenantAwareUsername(user);
+        String tenantDomain = MultitenantUtils.getTenantDomain(user);
+        if (StringUtils.isNotBlank(username) && StringUtils.isNotBlank(tenantDomain)) {
+            initiator = IdentityUtil.getInitiatorId(username, tenantDomain);
+        }
+        if (StringUtils.isBlank(initiator)) {
+            if (username.equals(CarbonConstants.REGISTRY_SYSTEM_USERNAME)) {
+                // If the initiator is wso2.system, we need not mask the username.
+                return LoggerUtils.Initiator.System.name();
+            }
+            initiator = LoggerUtils.getMaskedContent(user);
+        }
+        return initiator;
+    }
+
+    private static AuditLog.AuditLogBuilder buildAuditLogBuilder(String resourceId, String actionId) {
+
+        String initiatorId = getAuditInitiatorId();
+        return new AuditLog.AuditLogBuilder(
+                initiatorId,
+                LoggerUtils.getInitiatorType(initiatorId),
+                resourceId,
+                LoggerUtils.Target.User.name(),
+                actionId);
+    }
 
     /**
      * Returns the number of backup codes remaining for the given user.
@@ -135,5 +192,166 @@ public class BackupCodeAPIHandler {
             throw new BackupCodeClientException(ERROR_SETTING_USER_CLAIM_VALUES.getCode(),
                     String.format(ERROR_SETTING_USER_CLAIM_VALUES.getMessage()));
         }
+    }
+
+    /**
+     * Returns the number of backup codes remaining for the user identified by the given userID.
+     *
+     * @param userId       Unique ID of the user.
+     * @return The number of backup codes remaining for the user.
+     * @throws BackupCodeException If an error occurred while reading the backup codes claim.
+     */
+    public static int getRemainingBackupCodesCountByUserId(String userId) throws BackupCodeException {
+
+        if (StringUtils.isBlank(userId)) {
+            throw new BackupCodeClientException(ERROR_NO_USER_ID.getCode(),
+                    String.format(ERROR_NO_USER_ID.getMessage()));
+        }
+        String tenantDomain = IdentityTenantUtil.resolveTenantDomain();
+        try {
+            UniqueIDUserStoreManager userStoreManager = BackupCodeUtil.getUserStoreManagerOfTenant(tenantDomain);
+            Map<String, String> userClaimValues = userStoreManager
+                    .getUserClaimValuesWithID(userId, new String[]{BACKUP_CODES_CLAIM}, null);
+            String backupCodes = userClaimValues.get(BACKUP_CODES_CLAIM);
+            return StringUtils.isBlank(backupCodes) ? 0 : backupCodes.split(BACKUP_CODE_SEPARATOR).length;
+        } catch (UserStoreException e) {
+            throw new BackupCodeException(ERROR_ACCESS_USER_REALM.getCode(),
+                    String.format(ERROR_ACCESS_USER_REALM.getMessage(), userId, e));
+        }
+    }
+
+    /**
+     * Generate backup codes for the user identified by the given userID.
+     *
+     * @param userId       Unique ID of the user.
+     * @return List of generated plain-text backup codes (to be displayed once to the user).
+     * @throws BackupCodeException If an error occurred while generating the backup codes.
+     */
+    public static List<String> generateBackupCodesByUserId(String userId)
+            throws BackupCodeException {
+
+        if (StringUtils.isBlank(userId)) {
+            throw new BackupCodeClientException(ERROR_NO_USER_ID.getCode(),
+                    String.format(ERROR_NO_USER_ID.getMessage()));
+        }
+        String tenantDomain = IdentityTenantUtil.resolveTenantDomain();
+        UniqueIDUserStoreManager userStoreManager = BackupCodeUtil.getUserStoreManagerOfTenant(tenantDomain);
+        List<String> generatedBackupCodes = BackupCodeUtil.generateBackupCodes(tenantDomain);
+        ArrayList<String> hashedBackupCodesList = new ArrayList<>();
+        for (String backupCode : generatedBackupCodes) {
+            hashedBackupCodesList.add(BackupCodeUtil.generateHashBackupCode(backupCode));
+        }
+        String enabledAuthenticators = appendAuthenticator(getCurrentEnabledAuthenticators(userId, userStoreManager));
+        updateUserBackupCodesByUserId(userId, String.join(BACKUP_CODE_SEPARATOR, hashedBackupCodesList),
+                "true", enabledAuthenticators, userStoreManager);
+        triggerAuditLogEvent(buildAuditLogBuilder(userId, GENERATE_BACKUP_CODES));
+        return generatedBackupCodes;
+    }
+
+    /**
+     * Remove the stored remaining backup codes for the user identified by the given userID.
+     *
+     * @param userId       Unique ID of the user.
+     * @return {@code true} once the claims are reset.
+     * @throws BackupCodeException If an error occurred while clearing the backup codes claim.
+     */
+    public static boolean deleteBackupCodesByUserId(String userId) throws BackupCodeException {
+
+        if (StringUtils.isBlank(userId)) {
+            throw new BackupCodeClientException(ERROR_NO_USER_ID.getCode(),
+                    String.format(ERROR_NO_USER_ID.getMessage()));
+        }
+        String tenantDomain = IdentityTenantUtil.resolveTenantDomain();
+        UniqueIDUserStoreManager userStoreManager = BackupCodeUtil.getUserStoreManagerOfTenant(tenantDomain);
+        String enabledAuthenticators = removeAuthenticator(getCurrentEnabledAuthenticators(userId, userStoreManager));
+        updateUserBackupCodesByUserId(userId, StringUtils.EMPTY, "false", enabledAuthenticators,
+                userStoreManager);
+        triggerAuditLogEvent(buildAuditLogBuilder(userId, DELETE_BACKUP_CODES));
+        return true;
+    }
+
+    /**
+     * Write the backup-code claims for the user identified by the given userID.
+     *
+     * @param userId                Unique ID of the user.
+     * @param backupCodes           Comma-separated hashed backup codes (empty string clears the claim).
+     * @param isBackupCodesEnabled  "true" or "false".
+     * @param enabledAuthenticators Updated value for the enabledAuthenticators claim.
+     * @param userStoreManager      Resolved user store manager for the user's tenant.
+     * @throws BackupCodeException If the claim write fails.
+     */
+    private static void updateUserBackupCodesByUserId(String userId, String backupCodes,
+                                                      String isBackupCodesEnabled, String enabledAuthenticators,
+                                                      UniqueIDUserStoreManager userStoreManager)
+            throws BackupCodeException {
+
+        Map<String, String> claims = new HashMap<>();
+        claims.put(BACKUP_CODES_CLAIM, backupCodes);
+        claims.put(BACKUP_CODES_ENABLED_CLAIM, isBackupCodesEnabled);
+        claims.put(ENABLED_AUTHENTICATORS_CLAIM, enabledAuthenticators);
+        try {
+            userStoreManager.setUserClaimValuesWithID(userId, claims, null);
+        } catch (UserStoreClientException e) {
+            throw new BackupCodeClientException(ERROR_BACKUP_CODE_UPDATE_FAILURE.getCode(),
+                    String.format(ERROR_BACKUP_CODE_UPDATE_FAILURE.getMessage(), userId));
+        } catch (UserStoreException e) {
+            throw new BackupCodeException(ERROR_SETTING_USER_CLAIM_VALUES.getCode(),
+                    ERROR_SETTING_USER_CLAIM_VALUES.getMessage(), e);
+        }
+    }
+
+    /**
+     * Retrieve the current value of the enabledAuthenticators claim for the given user.
+     *
+     * @param userId           Unique ID of the user.
+     * @param userStoreManager Resolved user store manager for the user's tenant.
+     * @return Current claim value, or {@code null} if the claim is not set.
+     * @throws BackupCodeException If the claim read fails.
+     */
+    private static String getCurrentEnabledAuthenticators(String userId, UniqueIDUserStoreManager userStoreManager)
+            throws BackupCodeException {
+
+        try {
+            Map<String, String> claims = userStoreManager.getUserClaimValuesWithID(userId,
+                    new String[]{ENABLED_AUTHENTICATORS_CLAIM}, null);
+            return claims.get(ENABLED_AUTHENTICATORS_CLAIM);
+        } catch (UserStoreException e) {
+            throw new BackupCodeException(ERROR_ACCESS_USER_REALM.getCode(),
+                    String.format(ERROR_ACCESS_USER_REALM.getMessage(), userId, e));
+        }
+    }
+
+    /**
+     * Append backup-code-authenticator to a comma-separated list of enabled authenticators if not already present.
+     *
+     * @param enabledAuthenticators Current comma-separated authenticator list (may be null or blank).
+     * @return Updated comma-separated authenticator list.
+     */
+    private static String appendAuthenticator(String enabledAuthenticators) {
+
+        if (StringUtils.isBlank(enabledAuthenticators)) {
+            return BACKUP_CODE_AUTHENTICATOR_NAME;
+        }
+        List<String> authenticators = new ArrayList<>(Arrays.asList(enabledAuthenticators.split(",")));
+        if (!authenticators.contains(BACKUP_CODE_AUTHENTICATOR_NAME)) {
+            authenticators.add(BACKUP_CODE_AUTHENTICATOR_NAME);
+        }
+        return String.join(",", authenticators);
+    }
+
+    /**
+     * Remove backup-code-authenticator from a comma-separated list of enabled authenticators.
+     *
+     * @param enabledAuthenticators Current comma-separated authenticator list (may be null or blank).
+     * @return Updated comma-separated authenticator list, or empty string if none remain.
+     */
+    private static String removeAuthenticator(String enabledAuthenticators) {
+
+        if (StringUtils.isBlank(enabledAuthenticators)) {
+            return StringUtils.EMPTY;
+        }
+        List<String> authenticators = new ArrayList<>(Arrays.asList(enabledAuthenticators.split(",")));
+        authenticators.remove(BACKUP_CODE_AUTHENTICATOR_NAME);
+        return String.join(",", authenticators);
     }
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/constants/BackupCodeAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/constants/BackupCodeAuthenticatorConstants.java
@@ -67,12 +67,18 @@ public class BackupCodeAuthenticatorConstants {
 
             public static final String PROCESS_AUTHENTICATION_RESPONSE = "process-backupcode-authentication-response";
             public static final String INITIATE_BACKUP_CODE_REQUEST = "initiate-backupcode-authentication-request";
+            public static final String GET_REMAINING_BACKUP_CODES_COUNT = "get-remaining-backup-codes-count";
+            public static final String GENERATE_BACKUP_CODES = "generate-backup-codes";
+            public static final String DELETE_BACKUP_CODES = "delete-backup-codes";
         }
     }
 
     public enum ErrorMessages {
 
         ERROR_NO_USERNAME("60001", "Username cannot be empty"),
+        ERROR_NO_USER_ID("60002", "User ID cannot be empty"),
+        ERROR_BACKUP_CODE_UPDATE_FAILURE("60003", "Error occurred while updating backup code claim values for user: " +
+                "%s"),
         INVALID_FEDERATED_AUTHENTICATOR("65001", "No IDP found with the name IDP: " + "%s in tenant: %s"),
         ERROR_NO_FEDERATED_USER("65002", "No federated user found"),
         INVALID_FEDERATED_USER_AUTHENTICATION("65003", "Can not handle federated user " +
@@ -88,7 +94,8 @@ public class BackupCodeAuthenticatorConstants {
         ERROR_GETTING_CONFIG("65011", "Error occurred while getting backup code configurations"),
         ERROR_GETTING_THE_USER_REALM("65012", "Error occurred while getting the user realm"),
         ERROR_GETTING_THE_USER_STORE_MANAGER("65013", "Error occurred while getting the user store manager"),
-        ERROR_SETTING_USER_CLAIM_VALUES("65014", "Error occurred while setting user claim values");
+        ERROR_SETTING_USER_CLAIM_VALUES("65014", "Error occurred while setting user claim values"),
+        ERROR_UNSUPPORTED_USER_STORE("65015", "Userstore does not support unique ids"),;
 
         private final String code;
         private final String message;
@@ -126,5 +133,7 @@ public class BackupCodeAuthenticatorConstants {
         public static final String BACKUP_CODE_FAILED_ATTEMPTS_CLAIM =
                 "http://wso2.org/claims/identity/failedBackupCodeAttempts";
         public static final String ACCOUNT_LOCKED_REASON_CLAIM = "http://wso2.org/claims/identity/lockedReason";
+        public static final String ENABLED_AUTHENTICATORS_CLAIM =
+                "http://wso2.org/claims/identity/enabledAuthenticators";
     }
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/util/BackupCodeUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/application/authenticator/backupcode/util/BackupCodeUtil.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.carbon.identity.application.authenticator.backupcode.util;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.commons.lang.math.NumberUtils;
 import org.wso2.carbon.identity.application.authenticator.backupcode.exception.BackupCodeException;
 import org.wso2.carbon.identity.application.authenticator.backupcode.internal.BackupCodeDataHolder;
@@ -43,6 +44,7 @@ import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountLock
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
+import org.wso2.carbon.user.core.UniqueIDUserStoreManager;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
@@ -169,6 +171,40 @@ public class BackupCodeUtil {
                 return userStoreManager;
             }
             return ((AbstractUserStoreManager) userStoreManager).getSecondaryUserStoreManager(userStoreDomain);
+        } catch (UserStoreException e) {
+            throw new BackupCodeException(ERROR_GETTING_THE_USER_STORE_MANAGER.getCode(),
+                    ERROR_GETTING_THE_USER_STORE_MANAGER.getMessage(), e);
+        }
+    }
+
+    /**
+     * Get the primary {@link AbstractUserStoreManager} for the given tenant domain.
+     *
+     * @param tenantDomain Tenant domain.
+     * @return Primary AbstractUserStoreManager of the tenant.
+     * @throws BackupCodeException If the realm or user store manager cannot be resolved.
+     */
+    public static UniqueIDUserStoreManager getUserStoreManagerOfTenant(String tenantDomain)
+            throws BackupCodeException {
+
+        if (StringUtils.isBlank(tenantDomain)) {
+            throw new BackupCodeException(ERROR_GETTING_THE_USER_REALM.getCode(),
+                    ERROR_GETTING_THE_USER_REALM.getMessage());
+        }
+        try {
+            int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+            RealmService realmService = getRealmService();
+            UserRealm userRealm = realmService.getTenantUserRealm(tenantId);
+            if (userRealm == null) {
+                throw new BackupCodeException(ERROR_GETTING_THE_USER_REALM.getCode(),
+                        ERROR_GETTING_THE_USER_REALM.getMessage());
+            }
+            UserStoreManager userStoreManager = userRealm.getUserStoreManager();
+            if (!(userStoreManager instanceof UniqueIDUserStoreManager)) {
+                throw new BackupCodeException(ERROR_UNSUPPORTED_USER_STORE.getCode(),
+                        ERROR_UNSUPPORTED_USER_STORE.getMessage());
+            }
+            return (UniqueIDUserStoreManager) userStoreManager;
         } catch (UserStoreException e) {
             throw new BackupCodeException(ERROR_GETTING_THE_USER_STORE_MANAGER.getCode(),
                     ERROR_GETTING_THE_USER_STORE_MANAGER.getMessage(), e);

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAPIHandlerTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/application/authenticator/backupcode/BackupCodeAPIHandlerTest.java
@@ -26,12 +26,16 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.context.CarbonContext;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.application.authenticator.backupcode.exception.BackupCodeClientException;
 import org.wso2.carbon.identity.application.authenticator.backupcode.exception.BackupCodeException;
 import org.wso2.carbon.identity.application.authenticator.backupcode.util.BackupCodeUtil;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import org.wso2.carbon.user.api.UserStoreException;
-import org.wso2.carbon.user.api.UserStoreManager;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.util.ArrayList;
@@ -49,21 +53,51 @@ public class BackupCodeAPIHandlerTest {
 
     private final String username = "test1";
     private final String tenantAwareUserName = "test1";
+    private final String userID = "user-id-1";
+    private final String tenantDomain = "carbon.super";
 
     private AutoCloseable openMocks;
+    private MockedStatic<LoggerUtils> loggerUtilsMockedStatic;
+    private MockedStatic<CarbonContext> carbonContextMockedStatic;
+    private MockedStatic<IdentityUtil> identityUtilMockedStatic;
 
     @Mock
-    UserStoreManager userStoreManager;
+    AbstractUserStoreManager userStoreManager;
 
     @BeforeMethod
     public void setUp() {
+        System.setProperty("carbon.home", ".");
         openMocks = MockitoAnnotations.openMocks(this);
+
+        loggerUtilsMockedStatic = Mockito.mockStatic(LoggerUtils.class);
+        loggerUtilsMockedStatic.when(() -> LoggerUtils.getInitiatorType(Mockito.anyString())).thenReturn("User");
+        loggerUtilsMockedStatic.when(() -> LoggerUtils.triggerAuditLogEvent(Mockito.any()))
+                .thenAnswer(invocation -> null);
+
+        CarbonContext carbonContextMock = Mockito.mock(CarbonContext.class);
+        Mockito.when(carbonContextMock.getUsername()).thenReturn("");
+        Mockito.when(carbonContextMock.getTenantDomain()).thenReturn("carbon.super");
+        carbonContextMockedStatic = Mockito.mockStatic(CarbonContext.class);
+        carbonContextMockedStatic.when(CarbonContext::getThreadLocalCarbonContext).thenReturn(carbonContextMock);
+
+        identityUtilMockedStatic = Mockito.mockStatic(IdentityUtil.class);
+        identityUtilMockedStatic.when(() -> IdentityUtil.getInitiatorId(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(null);
     }
 
     @AfterMethod
     public void tearDown() throws Exception {
         if (openMocks != null) {
             openMocks.close();
+        }
+        if (loggerUtilsMockedStatic != null) {
+            loggerUtilsMockedStatic.close();
+        }
+        if (carbonContextMockedStatic != null) {
+            carbonContextMockedStatic.close();
+        }
+        if (identityUtilMockedStatic != null) {
+            identityUtilMockedStatic.close();
         }
     }
 
@@ -120,7 +154,7 @@ public class BackupCodeAPIHandlerTest {
     }
 
     @Test(dataProvider = "generateBackupCodesData")
-    public void testGenerateBackupCodes(List<String> backupCodes) throws BackupCodeException {
+    public void testGenerateBackupCodes(List<String> backupCodes) throws BackupCodeException, UserStoreException {
 
         String tenantDomain = "test.domain";
         try (MockedStatic<BackupCodeUtil> backupCodeUtilMockedStatic = Mockito.mockStatic(BackupCodeUtil.class);
@@ -134,6 +168,7 @@ public class BackupCodeAPIHandlerTest {
                     .thenReturn(userStoreManager);
             backupCodeUtilMockedStatic.when(() -> BackupCodeUtil.generateBackupCodes(tenantDomain))
                     .thenReturn(backupCodes);
+            when(userStoreManager.getUserIDFromUserName(username)).thenReturn(userID);
 
             assertEquals(backupCodes, BackupCodeAPIHandler.generateBackupCodes(username));
         }
@@ -164,7 +199,7 @@ public class BackupCodeAPIHandlerTest {
     }
 
     @Test
-    public void testDeleteBackupCodes() throws BackupCodeException {
+    public void testDeleteBackupCodes() throws BackupCodeException, UserStoreException {
 
         try (MockedStatic<BackupCodeUtil> backupCodeUtilMockedStatic = Mockito.mockStatic(BackupCodeUtil.class);
              MockedStatic<MultitenantUtils> multitenantUtilsMockedStatic = Mockito.mockStatic(MultitenantUtils.class)) {
@@ -173,6 +208,7 @@ public class BackupCodeAPIHandlerTest {
                     .thenReturn(tenantAwareUserName);
             backupCodeUtilMockedStatic.when(() -> BackupCodeUtil.getUserStoreManagerOfUser(username))
                     .thenReturn(userStoreManager);
+            when(userStoreManager.getUserIDFromUserName(tenantAwareUserName)).thenReturn(userID);
             assertTrue(BackupCodeAPIHandler.deleteBackupCodes(username));
         }
     }
@@ -183,4 +219,74 @@ public class BackupCodeAPIHandlerTest {
         BackupCodeAPIHandler.deleteBackupCodes("");
         BackupCodeAPIHandler.deleteBackupCodes(null);
     }
+
+    @Test(dataProvider = "backupCodesCountData")
+    public void testGetRemainingBackupCodesCountByUserId(Map<String, String> userClaimValues, String username,
+                                                        int remainingBackupCodesCount)
+            throws UserStoreException, BackupCodeException {
+
+        try (MockedStatic<BackupCodeUtil> backupCodeUtilMockedStatic = Mockito.mockStatic(BackupCodeUtil.class);
+             MockedStatic<IdentityTenantUtil> identityTenantUtilMockedStatic =
+                     Mockito.mockStatic(IdentityTenantUtil.class)) {
+
+            identityTenantUtilMockedStatic.when(IdentityTenantUtil::resolveTenantDomain).thenReturn(tenantDomain);
+            backupCodeUtilMockedStatic.when(() -> BackupCodeUtil.getUserStoreManagerOfTenant(tenantDomain))
+                    .thenReturn(userStoreManager);
+            when(userStoreManager.getUserClaimValuesWithID(userID, new String[]{BACKUP_CODES_CLAIM}, null))
+                    .thenReturn(userClaimValues);
+            assertEquals(remainingBackupCodesCount,
+                    BackupCodeAPIHandler.getRemainingBackupCodesCountByUserId(userID));
+        }
+    }
+
+    @Test(expectedExceptions = BackupCodeClientException.class)
+    public void testGetRemainingBackupCodesCountByUserIdBlankUserId() throws BackupCodeException {
+
+        BackupCodeAPIHandler.getRemainingBackupCodesCountByUserId("");
+    }
+
+    @Test(dataProvider = "generateBackupCodesData")
+    public void testGenerateBackupCodesByUserId(List<String> backupCodes)
+            throws BackupCodeException, UserStoreException {
+
+        try (MockedStatic<BackupCodeUtil> backupCodeUtilMockedStatic = Mockito.mockStatic(BackupCodeUtil.class);
+             MockedStatic<IdentityTenantUtil> identityTenantUtilMockedStatic =
+                     Mockito.mockStatic(IdentityTenantUtil.class)) {
+
+            identityTenantUtilMockedStatic.when(IdentityTenantUtil::resolveTenantDomain).thenReturn(tenantDomain);
+            backupCodeUtilMockedStatic.when(() -> BackupCodeUtil.getUserStoreManagerOfTenant(tenantDomain))
+                    .thenReturn(userStoreManager);
+            backupCodeUtilMockedStatic.when(() -> BackupCodeUtil.generateBackupCodes(tenantDomain))
+                    .thenReturn(backupCodes);
+
+            assertEquals(backupCodes, BackupCodeAPIHandler.generateBackupCodesByUserId(userID));
+        }
+    }
+
+    @Test(expectedExceptions = BackupCodeClientException.class)
+    public void testGenerateBackupCodesByUserIdBlankUserId() throws BackupCodeException {
+
+        BackupCodeAPIHandler.generateBackupCodesByUserId("");
+    }
+
+    @Test
+    public void testDeleteBackupCodesByUserId() throws BackupCodeException {
+
+        try (MockedStatic<BackupCodeUtil> backupCodeUtilMockedStatic = Mockito.mockStatic(BackupCodeUtil.class);
+             MockedStatic<IdentityTenantUtil> identityTenantUtilMockedStatic =
+                     Mockito.mockStatic(IdentityTenantUtil.class)) {
+
+            identityTenantUtilMockedStatic.when(IdentityTenantUtil::resolveTenantDomain).thenReturn(tenantDomain);
+            backupCodeUtilMockedStatic.when(() -> BackupCodeUtil.getUserStoreManagerOfTenant(tenantDomain))
+                    .thenReturn(userStoreManager);
+            assertTrue(BackupCodeAPIHandler.deleteBackupCodesByUserId(userID));
+        }
+    }
+
+    @Test(expectedExceptions = BackupCodeClientException.class)
+    public void testDeleteBackupCodesByUserIdBlankUserId() throws BackupCodeException {
+
+        BackupCodeAPIHandler.deleteBackupCodesByUserId("");
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
         <carbon.commons.version>4.4.8</carbon.commons.version>
         <carbon.commons.imp.pkg.version>[4.4.0, 5.0.0)</carbon.commons.imp.pkg.version>
         <!--Carbon identity version-->
-        <carbon.identity.framework.version>5.25.522</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.10.151</carbon.identity.framework.version>
 
         <org.wso2.carbon.identity.organization.management.core.version>1.0.0
         </org.wso2.carbon.identity.organization.management.core.version>


### PR DESCRIPTION
## Purpose
The existing backup code management APIs in BackupCodeAPIHandler operate on usernames. This change introduces equivalent user-ID-based APIs to support use cases where only the user's unique ID is available (e.g., REST API layers that work with user IDs instead of usernames).

## Goals
* Expose `getRemainingBackupCodesCountByUserId`, `generateBackupCodesByUserId`, and `deleteBackupCodesByUserId` methods that accept a user ID instead of a username.
* Resolve the `UserStoreManager` from the tenant domain when only the user ID is available, without requiring a username lookup.
* Emit audit log events for generate and delete operations, consistent with the existing username-based flows.

## Approach
* Added three new public methods to `BackupCodeAPIHandler` that mirror the existing username-based methods but use `AbstractUserStoreManager`'s `*WithID` APIs (`getUserClaimValuesWithID`, `setUserClaimValuesWithID`).
* Added `getUserStoreManagerOfTenant(String tenantDomain)` to `BackupCodeUtil` to resolve the primary `AbstractUserStoreManager` by tenant domain (used when no username context is available).
* Added `getAuditInitiatorId` / `buildAuditLogBuilder` helpers to share audit log construction across new and existing operations.
* Added new error codes `ERROR_NO_USER_ID` (60002) and `ERROR_BACKUP_CODE_UPDATE_FAILURE` (60003).
* Bumped `carbon.identity.framework.version` to `7.10.151` to pick up required `*WithID` user store APIs.

## Automation tests
* Unit tests added for all three new user-ID-based methods, including blank-user-ID negative cases.
* Updated existing tests to use AbstractUserStoreManager and mock the new CarbonContext/LoggerUtils/IdentityUtil dependencies introduced by the audit log helpers.

## Security checks
*Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
* Ran FindSecurityBugs plugin and verified report? yes
* Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related to 
* https://github.com/wso2/product-is/issues/28021

## Documentation
N/A — internal API addition; no end-user-facing documentation impact.

